### PR TITLE
#14 query, unsaved changes, error support

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ngrx-json-api</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { Action } from '@ngrx/store';
 
-import { Payload } from './interfaces';
+import { Payload, Resource, ResourceIdentifier } from './interfaces';
 import { type } from './utils';
 
 
@@ -19,6 +19,13 @@ export const NgrxJsonApiActionTypes = {
     API_DELETE_INIT: type('API_DELETE_INIT'),
     API_DELETE_SUCCESS: type('API_DELETE_SUCCESS'),
     API_DELETE_FAIL: type('API_DELETE_FAIL'),
+    API_POST_STORE_RESOURCE: type('API_POST_STORE_RESOURCE'),
+    API_PATCH_STORE_RESOURCE: type('API_PATCH_STORE_RESOURCE'),
+    API_DELETE_STORE_RESOURCE: type('API_DELETE_STORE_RESOURCE'),
+    API_COMMIT_INIT: type('API_COMMIT_INIT'),
+    API_COMMIT_SUCCESS: type('API_COMMIT_SUCCESS'),
+    API_COMMIT_FAIL: type('API_COMMIT_FAIL'),
+    API_ROLLBACK: type('API_ROLLBACK'),
     DELETE_FROM_STATE: type('DELETE_FROM_STATE')
 }
 
@@ -59,12 +66,12 @@ export class ApiUpdateInitAction implements Action {
 
 export class ApiUpdateSuccessAction implements Action {
     type = NgrxJsonApiActionTypes.API_UPDATE_SUCCESS;
-    constructor(public payload: Payload) { }
+    constructor(public payload: Payload) {console.log("update success", payload); }
 }
 
 export class ApiUpdateFailAction implements Action {
     type = NgrxJsonApiActionTypes.API_UPDATE_FAIL;
-    constructor(public payload: Payload) { }
+    constructor(public payload: Payload) {console.log("update failed", payload); }
 }
 
 export class ApiDeleteInitAction implements Action {
@@ -87,6 +94,41 @@ export class DeleteFromStateAction implements Action {
     constructor(public payload: Payload) { }
 }
 
+export class ApiPostStoreResourceAction implements Action {
+    type = NgrxJsonApiActionTypes.API_POST_STORE_RESOURCE;
+    constructor(public payload: Resource) { }
+}
+
+export class ApiPatchStoreResourceAction implements Action {
+    type = NgrxJsonApiActionTypes.API_PATCH_STORE_RESOURCE;
+    constructor(public payload: Resource) { }
+}
+
+export class ApiDeleteStoreResourceAction implements Action {
+    type = NgrxJsonApiActionTypes.API_DELETE_STORE_RESOURCE;
+    constructor(public payload: ResourceIdentifier) { }
+}
+
+export class ApiCommitInitAction implements Action {
+    type = NgrxJsonApiActionTypes.API_COMMIT_INIT;
+    constructor(public payload : String) { }
+}
+
+export class ApiCommitSuccessAction implements Action {
+    type = NgrxJsonApiActionTypes.API_COMMIT_SUCCESS;
+    constructor(public payload : Array<Action>) {}
+}
+
+export class ApiCommitFailAction implements Action {
+    type = NgrxJsonApiActionTypes.API_COMMIT_FAIL;
+    constructor(public payload : Array<Action>) { }
+}
+
+export class ApiRollbackAction implements Action {
+    type = NgrxJsonApiActionTypes.API_ROLLBACK;
+    constructor() { }
+}
+
 export type NgrxJsonApiActions
     = ApiCreateInitAction
     | ApiCreateSuccessAction
@@ -101,3 +143,10 @@ export type NgrxJsonApiActions
     | ApiDeleteSuccessAction
     | ApiDeleteFailAction
     | DeleteFromStateAction
+    | ApiPatchStoreResourceAction
+    | ApiDeleteStoreResourceAction
+    | ApiPostStoreResourceAction
+    | ApiCommitInitAction
+    | ApiCommitSuccessAction
+    | ApiCommitFailAction
+    | ApiRollbackAction

--- a/src/api.ts
+++ b/src/api.ts
@@ -30,8 +30,10 @@ import {
 } from './interfaces';
 
 import {
-    generateIncludedQueryParam,
-    generateFilteringParams,
+    generateIncludedQueryParams,
+    generateFieldsQueryParams,
+    generateFilteringQueryParams,
+    generateSortingQueryParams,
     generateQueryParams
 } from './utils';
 
@@ -41,7 +43,7 @@ export class NgrxJsonApi {
         'Content-Type': 'application/vnd.api+json',
         'Accept': 'application/vnd.api+json'
     });
-    public requestUrl: string;;
+    public requestUrl: string;
 
     constructor(
         private http: Http,
@@ -90,6 +92,8 @@ export class NgrxJsonApi {
         let queryParams = '';
         let includedParam: string = '';
         let filteringParams: string = '';
+        let sortingParams: string = '';
+        let fieldsParams: string = '';
 
         if (typeof query === undefined) {
             return Observable.throw('Query not found');
@@ -97,14 +101,20 @@ export class NgrxJsonApi {
 
         if (query.hasOwnProperty('params') && !_.isEmpty(query.params)) {
             if (_.hasIn(query.params, 'include')) {
-                includedParam = generateIncludedQueryParam(query.params.include);
+                includedParam = generateIncludedQueryParams(query.params.include);
             }
             if (_.hasIn(query.params, 'filtering')) {
-                filteringParams = generateFilteringParams(query.params.filtering);
+                filteringParams = generateFilteringQueryParams(query.params.filtering);
+            }
+            if (_.hasIn(query.params, 'filtering')) {
+              sortingParams = generateSortingQueryParams(query.params.sorting);
+            }
+            if (_.hasIn(query.params, 'fields')) {
+              fieldsParams = generateFieldsQueryParams(query.params.fields);
             }
         }
 
-        queryParams = generateQueryParams(includedParam, filteringParams);
+        queryParams = generateQueryParams(includedParam, filteringParams, sortingParams, fieldsParams);
 
         let requestOptionsArgs = {
             method: RequestMethod.Get,

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,5 +1,7 @@
 import { Injectable, OnDestroy } from '@angular/core';
+import { Response } from '@angular/http';
 
+import { Action, Store } from '@ngrx/store';
 import { Effect, Actions, toPayload } from '@ngrx/effects';
 
 import { Observable } from 'rxjs/Observable';
@@ -8,79 +10,230 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/switchMapTo';
+import 'rxjs/add/operator/toarray';
+import 'rxjs/add/operator/concatAll';
 import 'rxjs/add/operator/mapTo';
+import 'rxjs/add/operator/take';
 
 
 import {
-    NgrxJsonApiActionTypes,
-    ApiCreateInitAction,
-    ApiCreateSuccessAction,
-    ApiCreateFailAction,
-    ApiUpdateInitAction,
-    ApiUpdateSuccessAction,
-    ApiUpdateFailAction,
-    ApiReadInitAction,
-    ApiReadSuccessAction,
-    ApiReadFailAction,
-    ApiDeleteInitAction,
-    ApiDeleteSuccessAction,
-    ApiDeleteFailAction,
-    DeleteFromStateAction
+  NgrxJsonApiActionTypes,
+  ApiCreateSuccessAction,
+  ApiCreateFailAction,
+  ApiUpdateSuccessAction,
+  ApiUpdateFailAction,
+  ApiReadSuccessAction,
+  ApiReadFailAction,
+  ApiDeleteSuccessAction,
+  ApiDeleteFailAction,
+  ApiCommitSuccessAction,
+  ApiCommitFailAction,
 } from './actions';
 import { NgrxJsonApi } from './api';
-import { Payload } from './interfaces';
+import {Payload, ResourceError, ResourceQuery, NgrxJsonApiStore, StoreResource, ResourceState } from './interfaces';
 
 @Injectable()
 export class NgrxJsonApiEffects implements OnDestroy {
-    constructor(
-        private actions$: Actions,
-        private jsonApi: NgrxJsonApi
-    ) { }
+  constructor(
+    private actions$: Actions,
+    private jsonApi: NgrxJsonApi,
+    private store: Store<any>,
+  ) { }
 
-    @Effect() createResource$ = this.actions$
-        .ofType(NgrxJsonApiActionTypes.API_CREATE_INIT)
-        .map<Payload>(toPayload)
-        .mergeMap((payload: Payload) => {
-            return this.jsonApi.create(payload)
-                .mapTo(new ApiCreateSuccessAction(payload))
-                .catch(() => Observable.of(
-                    new ApiCreateFailAction(payload)
-                ));
-        });
+  @Effect() createResource$ = this.actions$
+    .ofType(NgrxJsonApiActionTypes.API_CREATE_INIT)
+    .map<Action, Payload>(toPayload)
+    .mergeMap((payload: Payload) => {
+      return this.jsonApi.create(payload)
+        .mapTo(new ApiCreateSuccessAction(payload))
+        .catch(() => Observable.of(
+          new ApiCreateFailAction(payload)
+        ));
+    });
 
-    @Effect() updateResource$ = this.actions$
-        .ofType(NgrxJsonApiActionTypes.API_UPDATE_INIT)
-        .map<Payload>(toPayload)
-        .mergeMap((payload: Payload) => {
-            return this.jsonApi.update(payload)
-                .mapTo(new ApiUpdateSuccessAction(payload))
-                .catch(() => Observable.of(new ApiUpdateFailAction(payload)));
-        });
+  @Effect() updateResource$ = this.actions$
+    .ofType(NgrxJsonApiActionTypes.API_UPDATE_INIT)
+    .map<Action, Payload>(toPayload)
+    .mergeMap((payload: Payload) => {
+      return this.jsonApi.update(payload)
+        .mapTo(new ApiUpdateSuccessAction(payload))
+        .catch(() => Observable.of(new ApiUpdateFailAction(payload)));
+    });
 
-    @Effect() readResource$ = this.actions$
-        .ofType(NgrxJsonApiActionTypes.API_READ_INIT)
-        .map<Payload>(toPayload)
-        .mergeMap((payload: Payload) => {
-            return this.jsonApi.find(payload)
-                .map(res => res.json())
-                .map(data => new ApiReadSuccessAction({
-                  jsonApiData: data,
-                  query: payload.query
-                }))
-                .catch(() => Observable.of(new ApiReadFailAction(payload)));
-        });
+  @Effect() readResource$ = this.actions$
+    .ofType(NgrxJsonApiActionTypes.API_READ_INIT)
+    .map<Action, Payload>(toPayload)
+    .mergeMap((payload: Payload) => {
+      return this.jsonApi.find(payload)
+        .map(res => res.json())
+        .map(data => new ApiReadSuccessAction({
+          jsonApiData: data,
+          query: payload.query
+        }))
+        .catch(() => Observable.of(new ApiReadFailAction(payload)));
+    });
 
-    @Effect() deleteResource$ = this.actions$
-        .ofType(NgrxJsonApiActionTypes.API_DELETE_INIT)
-        .map<Payload>(toPayload)
-        .mergeMap((payload: Payload) => {
-            return this.jsonApi.delete(payload)
-                .mapTo(new ApiDeleteSuccessAction(payload))
-                .catch(() => Observable.of(new ApiDeleteFailAction(payload)));
-        });
+  @Effect() deleteResource$ = this.actions$
+    .ofType(NgrxJsonApiActionTypes.API_DELETE_INIT)
+    .map<Action, Payload>(toPayload)
+    .mergeMap((payload: Payload) => {
+      return this.jsonApi.delete(payload)
+        .mapTo(new ApiDeleteSuccessAction(payload))
+        .catch(() => Observable.of(new ApiDeleteFailAction(payload)));
+    });
 
-    ngOnDestroy() {
+  @Effect() commitResources$ = this.actions$
+    .ofType(NgrxJsonApiActionTypes.API_COMMIT_INIT)
+    .map<Action, string>(toPayload)
+    .mergeMap((storeLocation : string) => this.store.select(storeLocation).take(1))
+    .mergeMap((store : NgrxJsonApiStore) => {
+      // TODO add support for bulk updates as well (jsonpatch, etc.)
+      // to get atomicity for multiple updates
 
+      console.log("commit", store);
+
+      let pending : Array<StoreResource> = this.getPendingChanges(store);
+      console.log("pending", pending);
+
+      if(pending.length > 0){
+        pending = this.sortPendingChanges(pending);
+
+        let actions : Array<Observable<Action>> = [];
+        for(let pendingChange of pending){
+          if(pendingChange.state == ResourceState.CREATED){
+            let payload : Payload = {
+              jsonApiData : {
+                data : {
+                  id :  pendingChange.resource.id,
+                  type :  pendingChange.resource.type,
+                  attributes :  pendingChange.resource.attributes,
+                  relationships :  pendingChange.resource.relationships
+                },
+              },
+              query : {
+                queryType : 'create',
+                type : pendingChange.resource.type
+              }
+            };
+            actions.push(this.jsonApi.create(payload)
+              .mapTo(new ApiCreateSuccessAction(payload))
+              .catch(error => Observable.of(new ApiCreateFailAction(this.toErrorPayload(payload.query, error))))
+            );
+          }else if(pendingChange.state == ResourceState.UPDATED){
+            // prepare payload, omit links and meta information
+            let payload : Payload = {
+              jsonApiData : {
+                data : {
+                  id :  pendingChange.resource.id,
+                  type :  pendingChange.resource.type,
+                  attributes :  pendingChange.resource.attributes,
+                  relationships :  pendingChange.resource.relationships
+                },
+              },
+              query : {
+                queryType : 'update',
+                type : pendingChange.resource.type,
+                id : pendingChange.resource.id
+              }
+            };
+            actions.push(this.jsonApi.update(payload)
+              .map(res => res.json())
+              .map(data => new ApiUpdateSuccessAction({
+                jsonApiData: data,
+                query: payload.query
+              }))
+              .catch(error => Observable.of(new ApiUpdateFailAction(this.toErrorPayload(payload.query, error))))
+            );
+          }else if(pendingChange.state == ResourceState.DELETED){
+            let payload : Payload = {
+              query : {
+                queryType : 'deleteOne',
+                type : pendingChange.resource.type,
+                id : pendingChange.resource.id
+              }
+            };
+            actions.push(this.jsonApi.delete(payload)
+              .map(res => res.json())
+              .map(data => new ApiDeleteSuccessAction({
+                jsonApiData: data,
+                query: payload.query
+              }))
+              .catch(error => Observable.of(new ApiDeleteFailAction(this.toErrorPayload(payload.query, error))))
+            );
+          }else{
+            throw new Error("unknown state " + pendingChange.state);
+          }
+        }
+
+        return actions[0];
+
+        //return Observable.of(...actions).map(it => {console.log(it); return it;}).concatAll().toArray().map(actions => this.toCommitAction(actions));
+      }else{
+        return Observable.of(new ApiCommitSuccessAction([]));
+      }
+    });
+
+  private toCommitAction(actions : Array<Action>){
+    console.log("actions done", actions);
+    for(let action of actions){
+      if(action.type == NgrxJsonApiActionTypes.API_CREATE_FAIL
+        || action.type == NgrxJsonApiActionTypes.API_CREATE_FAIL
+        || action.type == NgrxJsonApiActionTypes.API_CREATE_FAIL){
+        return new ApiCommitFailAction(actions);
+      }
     }
+    return new ApiCommitSuccessAction(actions);
+  }
+
+  private toErrorPayload(query : ResourceQuery, response : Response) : Payload{
+    var document = response.json();
+    if(document && document.errors && document.errors.length > 0){
+      // got json api errors
+      return {
+        query : query,
+        jsonApiData : document
+      }
+    }else{
+      // transform http to json api error
+      let errors : Array<ResourceError> = [];
+
+      let error : ResourceError = {
+        status : response.status.toString(),
+        code : response.statusText
+      };
+      errors.push(error);
+
+      return {
+        query : query,
+        jsonApiData : {
+          errors : errors
+        }
+      };
+    }
+  }
+
+  private sortPendingChanges(pending :  Array<StoreResource>) : Array<StoreResource> {
+    return pending; // TODO we need sorting? by change order?
+  }
+
+  private getPendingChanges(state : NgrxJsonApiStore) : Array<StoreResource> {
+    let pending : Array<StoreResource> = [];
+    for(let type in state.data){
+      console.log(type);
+      for(let id in state.data[type]){
+        console.log(id);
+        let storeResource = state.data[type][id];
+        if(storeResource.state != ResourceState.IN_SYNC){
+           pending.push(storeResource);
+        }
+      }
+    }
+    return pending;
+  }
+
+
+  ngOnDestroy() {
+
+  }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,12 @@
+
+export * from './actions';
+export * from './api';
+export * from './effects';
+export * from './interfaces';
+export * from './module';
+export * from './reducers';
+export * from './selectors';
+export * from './services';
+export * from './utils';
+export * from './testing';
+

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,7 +9,7 @@ export interface ResourceDefinition {
     collectionPath: string;
 };
 
-export interface FilteringParams {
+export interface FilteringParam {
     field?: string;
     value?: any;
     type?: string;
@@ -17,9 +17,23 @@ export interface FilteringParams {
     api?: string;
 }
 
+export enum Direction {
+  ASC,
+  DESC
+}
+
+export interface SortingParam {
+  api : string;
+  direction : Direction;
+}
+
 export interface QueryParams {
-    filtering?: Array<FilteringParams>
+    filtering?: Array<FilteringParam>
+    sorting?: Array<SortingParam>
     include?: Array<string>
+    fields?: Array<string>
+    offset?: number
+    limit?: number
 }
 
 export type QueryType
@@ -31,7 +45,13 @@ export type QueryType
     | 'create'
 
 export interface ResourceQuery {
-    type?: string;
+
+	/**
+	 * id to reference the query within the store. Does not have any impact on the actual query.
+     */
+    queryId?: string;
+
+	type?: string;
     id?: string;
     params?: QueryParams;
     queryType?: QueryType;
@@ -42,14 +62,73 @@ export interface ResourceIdentifier {
     id: string;
 }
 
+export enum ResourceState{
+    IN_SYNC,
+    CREATED,
+    UPDATED,
+    DELETED
+}
+
+export interface ResourceError{
+    id?: string;
+    links?: any;
+    status?: string;
+    code?: string;
+    title?: string;
+    detail?: string;
+    source?: ResourceErrorSource;
+    meta?:any;
+}
+
+export interface ResourceErrorSource{
+    pointer?: string;
+    parameter?: string;
+}
+
+/**
+ * Container to hold a Resource in the store with state information.
+ */
+export interface StoreResource {
+
+	/**
+	 * State of the resource to track local changes not yet published to the json api endpoint.
+     */
+    state? : ResourceState;
+
+	/**
+	 * The actual resource. This corresponds to originalResource if no changes were applied.
+     */
+    resource : Resource;
+
+	/**
+	 * The original resource obtained from the server.
+     */
+    originalResource : Resource;
+
+	/**
+	 * True if any kind of operation is executed (post, patch, delete).
+     */
+    loading? : boolean;
+
+	/**
+	 * Errors received from the server after attempting to store the resource.
+     */
+    errors : Array<ResourceError>
+}
+
 export interface Resource extends ResourceIdentifier {
     attributes?: { [key: string]: any };
     relationships?: { [key: string]: any };
+    meta?: any;
+    links?: any;
 }
 
 export interface Document {
     data?: any;
     included?: any;
+    meta?: any;
+    links?: any;
+    errors?: Array<ResourceError>
 }
 
 export interface Payload {
@@ -57,15 +136,29 @@ export interface Payload {
     query: ResourceQuery;
 }
 
-export type NgrxJsonApiStoreResources = { [id: string]: Resource };
+export interface NgrxJsonApiStoreQuery{
+  query : ResourceQuery;
+  loading : Boolean;
+  resultIds : Array<ResourceIdentifier>
+
+  /**
+   * Errors received from the server after attempting to perform a GET request.
+   */
+  errors : Array<ResourceError>
+}
+
+export type NgrxJsonApiStoreResources = { [id: string]: StoreResource };
 export type NgrxJsonApiStoreData = { [key: string]: NgrxJsonApiStoreResources };
+export type NgrxJsonApiStoreQueries = { [key: string]: NgrxJsonApiStoreQuery };
 
 export interface NgrxJsonApiStore {
     data: NgrxJsonApiStoreData;
+    queries: NgrxJsonApiStoreQueries;
     isCreating: boolean;
     isReading: boolean;
     isUpdating: boolean;
     isDeleting: boolean;
+    isCommitting: boolean;
 }
 
 export interface NgrxJsonApiModuleConfig {

--- a/src/module.ts
+++ b/src/module.ts
@@ -11,7 +11,7 @@ import { NgrxJsonApi } from './api';
 import { NgrxJsonApiEffects } from './effects';
 import { NgrxJsonApiActions } from './actions';
 import { NgrxJsonApiSelectors } from './selectors';
-import { NgrxJsonApiService } from './services';
+import { NgrxJsonApiService, NgrxJsonApiServiceV2 } from './services';
 
 import { ResourceDefinition, NgrxJsonApiModuleConfig } from './interfaces';
 
@@ -39,6 +39,12 @@ export const serviceFactory = (
     return new NgrxJsonApiService<any>(store, selectors);
 }
 
+export const serviceFactoryV2 = (
+    store: Store<any>,
+    selectors: NgrxJsonApiSelectors<any>) => {
+    return new NgrxJsonApiServiceV2<any>(store, selectors);
+}
+
 export const configure = (config: NgrxJsonApiModuleConfig): Array<any> => {
 
     return [
@@ -64,6 +70,11 @@ export const configure = (config: NgrxJsonApiModuleConfig): Array<any> => {
         {
             provide: NgrxJsonApiService,
             useFactory: serviceFactory,
+            deps: [Store, NgrxJsonApiSelectors]
+        },
+        {
+            provide: NgrxJsonApiServiceV2,
+            useFactory: serviceFactoryV2,
             deps: [Store, NgrxJsonApiSelectors]
         }
     ]

--- a/src/services.ts
+++ b/src/services.ts
@@ -11,11 +11,17 @@ import {
   ApiUpdateInitAction,
   ApiDeleteInitAction,
   DeleteFromStateAction,
+  ApiPostStoreResourceAction,
+  ApiPatchStoreResourceAction,
+  ApiDeleteStoreResourceAction,
+  ApiCommitInitAction,
 } from './actions';
 import {
   ResourceQuery,
   Payload,
-  QueryType
+  QueryType,
+  Resource,
+  ResourceIdentifier
 } from './interfaces';
 
 @Injectable()
@@ -48,4 +54,95 @@ export class NgrxJsonApiService<T> {
   public deleteFromState(payload: Payload) {
     return this.store.dispatch(new DeleteFromStateAction(payload));
   }
+}
+
+
+@Injectable()
+export class NgrxJsonApiServiceV2<T> {
+
+  private test: boolean = true;
+  constructor(
+      private store: Store<T>,
+      private selectors: NgrxJsonApiSelectors<T>) {}
+
+
+  public getOne(query: ResourceQuery) {
+    query.queryType = "getOne";
+    var result = this.getInternal(query);
+    if(result != null){
+      return result.map(it => {
+        if(it.length == 0){
+          return null;
+        }else if(it.length == 1){
+          return it[0];
+        }else{
+          throw new Error("Unique result expected");
+        }
+      });
+    }else{
+      return null;
+    }
+  }
+
+  public getMany(query: ResourceQuery) {
+    query.queryType = "getMany";
+    return this.getInternal(query);
+  }
+
+  private getInternal(query: ResourceQuery) {
+    let payload : Payload = {
+      query: query
+    };
+    this.store.dispatch(new ApiReadInitAction(payload));
+
+    let queryId = query.queryId;
+    if(queryId != null){
+      return this.selectQuery(queryId);
+    }else{
+      return null;
+    }
+  }
+
+  public selectQuery(queryId: string) : Observable<Array<Resource>> {
+    return this.selectors.getQuery$(this.store, queryId);
+  }
+
+  /**
+   * Updates the given resource in the store with the provided data.
+   * Use commit() to send the changes to the remote JSON API endpoint.
+   *
+   * @param resource
+   */
+  public patchResource(resource: Resource) {
+    this.store.dispatch(new ApiPatchStoreResourceAction(resource));
+  }
+
+  /**
+   * Adds the given resource to the store. Any already existing
+   * resource with the same id gets replaced. Use commit() to send
+   * the changes to the remote JSON API endpoint.
+   *
+   * @param resource
+   */
+  public postResource(resource: Resource) {
+    this.store.dispatch(new ApiPostStoreResourceAction(resource));
+  }
+
+  /**
+   * Marks the given resource for deletion.
+   *
+   * @param resourceId
+   */
+  public deleteResource(resourceId: ResourceIdentifier) {
+    this.store.dispatch(new ApiDeleteStoreResourceAction(resourceId));
+  }
+
+  /**
+   * Applies all pending changes to the remote JSON API endpoint.
+   */
+  public commit() {
+    let storeLocation = this.selectors.storeLocation;
+    this.store.dispatch(new ApiCommitInitAction(storeLocation));
+  }
+
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,16 +4,23 @@ import * as _ from 'lodash';
 import { Actions } from '@ngrx/effects';
 
 import {
-    FilteringParams,
+    FilteringParam,
+    SortingParam,
+    Direction,
     Resource,
+    StoreResource,
     NgrxJsonApiStore,
     NgrxJsonApiStoreData,
     NgrxJsonApiStoreResources,
+    NgrxJsonApiStoreQueries,
+    NgrxJsonApiStoreQuery,
     ResourceIdentifier,
+    ResourceState,
     ResourceDefinition,
     Document,
     RelationDefinition,
-    ResourceQuery
+    ResourceQuery,
+    QueryParams,
 } from './interfaces';
 
 export const denormaliseObject = (
@@ -85,8 +92,14 @@ export const denormaliseResource = (
 
         let obj = Object.assign({}, resource);
 
-        bag[resource.type][resource.id] = obj;
-        bag[resource.type][resource.id] = denormaliseObject(obj, resources, bag);
+        var storeResource : StoreResource = {
+            errors : [],
+            resource : obj,
+            originalResource : obj
+        };
+
+        bag[resource.type][resource.id] = storeResource;
+        storeResource.resource = denormaliseObject(obj, resources, bag);
     }
 
     return bag[resource.type][resource.id];
@@ -98,7 +111,8 @@ export const getSingleResource = (
     if (_.isUndefined(resources[query.type])) {
         return undefined;
     }
-    return resources[query.type][query.id];
+    let storeResource = resources[query.type][query.id];
+    return storeResource ? storeResource.resource : null;
 }
 
 export const getMultipleResources = (
@@ -138,65 +152,262 @@ export const updateResourceObject = (original: Resource,
 
 };
 
-export const insertResource = (state: NgrxJsonApiStoreResources,
-    resource: Resource): NgrxJsonApiStoreResources => {
+export const insertStoreResource = (state: NgrxJsonApiStoreResources,
+    resource: Resource, fromServer : boolean): NgrxJsonApiStoreResources => {
+
     let newState = Object.assign({}, state);
-    newState[resource.id] = resource
+    if(fromServer){
+        newState[resource.id] = {
+            resource : resource,
+            originalResource : resource,
+            state : ResourceState.CREATED,
+            errors : [],
+            loading : false
+        };
+    }else{
+        newState[resource.id] = {
+            resource : resource,
+            originalResource : null,
+            state : ResourceState.CREATED,
+            errors : [],
+            loading : false
+        };
+    }
+
     return newState;
 
 };
 
-export const updateResource = (state: NgrxJsonApiStoreResources,
-    resource: Resource, foundResource: Resource): NgrxJsonApiStoreResources => {
+export const updateStoreResource = (state: NgrxJsonApiStoreResources,
+    resource: Resource, fromServer : boolean): NgrxJsonApiStoreResources => {
+
+    let foundResource = state[resource.id].resource;
+    let originalResource = state[resource.id].originalResource;
+
+    let newResource : Resource;
+    let newResourceState : ResourceState;
+    if(fromServer){
+        // form server, override everything
+        // TODO need to handle check and keep local updates?
+        newResource= resource;
+        originalResource = resource;
+        newResourceState = ResourceState.IN_SYNC;
+    }else {
+        let mergedResource = updateResourceObject(foundResource, resource);
+        if (_.isEqual(mergedResource, originalResource)) {
+            // no changes anymore, do nothing
+            newResource = originalResource;
+            newResourceState = ResourceState.IN_SYNC;
+        }
+        else {
+            // merge changes and mark as CREATED or UPDATED depending on whether
+            // an original version is available
+            newResource = mergedResource;
+            newResourceState = originalResource == null ? ResourceState.CREATED : ResourceState.UPDATED;
+        }
+    }
 
     let newState = Object.assign({}, state);
-    newState[resource.id] = updateResourceObject(foundResource, resource);
+    newState[resource.id] = {
+        resource : newResource,
+        originalResource : originalResource,
+        state : newResourceState,
+        errors : [],
+        loading : false
+    };
     return newState;
+};
+
+
+export const updateQueryErrors = (state: NgrxJsonApiStoreQueries, queryId: string, document : Document): NgrxJsonApiStoreQueries => {
+  if(!queryId || !state[queryId]){
+    return state;
+  }
+  let newState = Object.assign({}, state);
+  let newStoreQuery = Object.assign({}, newState[queryId]);
+  newStoreQuery.errors.length = 0;
+  if(document.errors){
+    newStoreQuery.errors.push(...document.errors);
+  }
+  newState[queryId] = newStoreQuery;
+  return newState;
+}
+
+
+export const updateResourceErrors = (state: NgrxJsonApiStoreData, query: ResourceQuery, document : Document): NgrxJsonApiStoreData => {
+  if(!query.type || !query.id || document.data instanceof Array){
+    throw new Error("invalid parameters");
+  }
+  if(!state[query.type] || !state[query.type][query.id]){
+    // resource is not locally stored, no need to update(?)
+    return state;
+  }
+
+  let newState: NgrxJsonApiStoreData = Object.assign({}, state);
+  newState[query.type] = Object.assign({}, newState[query.type]);
+  let storeResource =  Object.assign({}, newState[query.type][query.id]);;
+  storeResource.errors.length = 0;
+  if(document.errors){
+    storeResource.errors.push(...document.errors);
+  }
+  newState[query.type][query.id] = storeResource;
+  return newState;
+}
+
+export const rollbackStoreResources = (state: NgrxJsonApiStoreData): NgrxJsonApiStoreData => {
+  let newState: NgrxJsonApiStoreData = Object.assign({}, state);
+  for(let type in newState){
+    newState[type] = Object.assign({}, newState[type]);
+    for(let id in newState[type]){
+      let storeResource = newState[type][id];
+      if(storeResource.originalResource == null){
+        delete newState[type][id];
+      }else if(storeResource.state != ResourceState.IN_SYNC){
+        newState[type][id] = Object.assign({}, newState[type][id], {
+          state : ResourceState.IN_SYNC,
+          resource :  newState[type][id].originalResource
+        });
+      }
+    }
+  }
+  return newState;
 };
 
 export const updateOrInsertResource = (state: NgrxJsonApiStoreData,
-    resource: Resource): NgrxJsonApiStoreData => {
+    resource: Resource, fromServer : boolean, override : boolean): NgrxJsonApiStoreData => {
 
     let newState: NgrxJsonApiStoreData = Object.assign({}, state);
 
     // handle relationships first.
-    if (resource.hasOwnProperty('relationships')) {
-        Object.keys(resource.relationships)
-            .forEach(relation => {
-                let data = resource.relationships[relation].data;
-                if (_.isPlainObject(data)) {
-                    // hasOne relation
-                    newState = updateOrInsertResource(state, data);
-                } else if (_.isArray(data)) {
-                    // hasMany relation
-                    newState = <NgrxJsonApiStoreData>data.reduce(
-                        (partialState: NgrxJsonApiStoreData, currentResource: Resource): NgrxJsonApiStoreData => {
-                            return updateOrInsertResource(partialState, currentResource);
-                        }, newState);
-                }
-            });
-    }
+    // FIXME this is not working, the data section of a relationship contains only <type, id>, not a complete resource
+    //if (resource.hasOwnProperty('relationships')) {
+    //    Object.keys(resource.relationships)
+    //       .forEach(relation => {
+    //           let data = resource.relationships[relation].data;
+    //           if (_.isPlainObject(data)) {
+    //               // hasOne relation
+    //               newState = updateOrInsertResource(state, data, resourceState);
+    //           } else if (_.isArray(data)) {
+    //                // hasMany relation
+    //                newState = <NgrxJsonApiStoreData>data.reduce(
+    //                    (partialState: NgrxJsonApiStoreData, currentResource: Resource): NgrxJsonApiStoreData => {
+    //                        return updateOrInsertResource(partialState, currentResource, resourceState);
+    //                    }, newState);
+    //            }
+    //        });
+    //}
 
     if (_.isUndefined(state[resource.type])) {
         // we must mutate the main state (ngrxjsonapistoredata)
         newState[resource.type] = {};
-        newState[resource.type] = insertResource(newState[resource.type], resource);
+        newState[resource.type] = insertStoreResource(newState[resource.type], resource, fromServer);
         return newState;
 
-    } else if (_.isUndefined(state[resource.type][resource.id])) {
-        newState[resource.type] = insertResource(
-            newState[resource.type],
-            resource);
+    } else if (_.isUndefined(state[resource.type][resource.id]) || override) {
+        newState[resource.type] = insertStoreResource(
+            newState[resource.type], resource, fromServer);
         return newState;
     } else {
-        newState[resource.type] = updateResource(
-            newState[resource.type],
-            resource,
-            state[resource.type][resource.id]);
+        newState[resource.type] = updateStoreResource(
+            newState[resource.type], resource, fromServer);
         return newState;
     }
 
 };
+
+/**
+ * Updates the state of a resource in the store.
+ *
+ * @param state
+ * @param resourceId
+ * @param resourceState
+ * @param loading
+ * @returns {NgrxJsonApiStoreData}
+ */
+export const updateResourceState = (state: NgrxJsonApiStoreData,
+    resourceId: ResourceIdentifier, resourceState? : ResourceState, loading? : boolean): NgrxJsonApiStoreData => {
+    if (_.isUndefined(state[resourceId.type]) || _.isUndefined(state[resourceId.type][resourceId.id])) {
+        return state;
+    }
+    let newState: NgrxJsonApiStoreData = Object.assign({}, state);
+    newState[resourceId.type] = Object.assign({}, newState[resourceId.type]);
+    newState[resourceId.type][resourceId.id] = Object.assign({}, newState[resourceId.type][resourceId.id]);
+    if(resourceState != null){
+        newState[resourceId.type][resourceId.id].state = resourceState;
+    }
+    if(loading != null){
+        newState[resourceId.type][resourceId.id].loading = loading;
+    }
+    return newState;
+};
+
+export const cloneQueryParams = (queryParams: QueryParams): QueryParams => {
+    let newQueryParams : QueryParams = {};
+    if(queryParams.include){
+      newQueryParams.include = queryParams.include.splice(0);
+    }
+    if(queryParams.fields){
+      newQueryParams.fields = queryParams.fields.splice(0);
+    }
+    if(queryParams.filtering){
+      newQueryParams.filtering = queryParams.filtering.map(it => Object.assign({}, it));
+    }
+    if(queryParams.sorting){
+      newQueryParams.sorting = queryParams.sorting.map(it => Object.assign({}, it));
+    }
+    return newQueryParams;
+}
+
+export const cloneResourceQuery = (query: ResourceQuery): ResourceQuery => {
+    let newQuery = Object.assign({}, query);
+    if(newQuery.params){
+        newQuery.params = cloneQueryParams(newQuery.params);
+    }
+    return newQuery;
+}
+
+/**
+ * Updates the query information for the given query in the store.
+ */
+export const updateQueryParams = (state: NgrxJsonApiStoreQueries,
+    query: ResourceQuery): NgrxJsonApiStoreQueries => {
+
+    let storeQuery : NgrxJsonApiStoreQuery = state[query.queryId];
+    let newQueryStore = Object.assign({}, storeQuery);
+    newQueryStore.loading = true;
+    newQueryStore.query = cloneResourceQuery(query);
+
+    let newState: NgrxJsonApiStoreQueries = Object.assign({}, state);
+    newState[query.queryId] = newQueryStore;
+    return newState;
+}
+
+const toResourceIdentifier = (resource: Resource): ResourceIdentifier => {
+    return {type: resource.type, id : resource.id};
+}
+
+
+/**
+ * Updates the query results for the given query in the store.
+ */
+export const updateQueryResults = (state: NgrxJsonApiStoreQueries, queryId : string,
+    document: Document): NgrxJsonApiStoreQueries => {
+
+    let storeQuery : NgrxJsonApiStoreQuery = state[queryId];
+    if(storeQuery){
+        let data = _.isArray(document.data) ? document.data : [document.data];
+        let newQueryStore = Object.assign({}, storeQuery, {
+            resultIds : data.map(it => toResourceIdentifier(it)),
+            loading : false
+        });
+
+        let newState: NgrxJsonApiStoreQueries = Object.assign({}, state);
+        newState[queryId] = newQueryStore;
+        return newState;
+    }
+    return state;
+}
+
 
 export const updateStoreResources = (state: NgrxJsonApiStoreData,
     payload: Document): NgrxJsonApiStoreData => {
@@ -225,7 +436,7 @@ export const updateStoreResources = (state: NgrxJsonApiStoreData,
             // newPartialState.data[resourcePath] = { data: {} } ;
             // newPartialState.data = updateOrInsertResource(
             // result.data, resource);
-            return updateOrInsertResource(result, resource)
+            return updateOrInsertResource(result, resource, true, true)
             // result.data[resourcePath].data = updateOrInsertResource(
             // result.data[resourcePath].data, resource);
             // return <NgrxJsonApiStore>_.merge({}, result, newPartialState);
@@ -363,7 +574,7 @@ export function type<T>(label: T | ''): T {
     return <T>label;
 }
 
-export const generateIncludedQueryParam = (included: Array<string>): string => {
+export const generateIncludedQueryParams = (included: Array<string>): string => {
     if (_.isEmpty(included)) {
         return '';
     }
@@ -372,18 +583,32 @@ export const generateIncludedQueryParam = (included: Array<string>): string => {
 
 }
 
-export const generateFilteringParams = (filtering: Array<FilteringParams>): string => {
+export const generateFieldsQueryParams = (fields: Array<string>): string => {
+  if (_.isEmpty(fields)) {
+    return '';
+  }
 
-    if (_.isEmpty(filtering)) {
-      return '';
-    }
-    let filteringParams = filtering.map(f => 'filter[' + f.api + ']=' + f.value);
-
-    return filteringParams.join('&');
+  return 'fields=' + fields.join();
 
 }
 
-export const generateQueryParams = (first: string, second: string) => {
+export const generateFilteringQueryParams = (filtering: Array<FilteringParam>): string => {
+    if (_.isEmpty(filtering)) {
+      return '';
+    }
+    let filteringParams = filtering.map(f => 'filter[' + f.api + ']'+ (f.type ? '[' + f.type + ']' : '') + '=' + encodeURIComponent(f.value));
+    return filteringParams.join('&');
+}
+
+export const generateSortingQueryParams = (sorting: Array<SortingParam>): string => {
+  if (_.isEmpty(sorting)) {
+    return '';
+  }
+  return "sort=" +  sorting.map(f => (f.direction == Direction.ASC ? '' : '-') + f.api).join(",");
+
+}
+
+export const generateQueryParams = (first: string, second: string, third: string, forth: string) => {
 
   let arrayOfParams: Array<string> = []
 
@@ -393,6 +618,14 @@ export const generateQueryParams = (first: string, second: string) => {
 
   if (second !== '') {
     arrayOfParams.push(second);
+  }
+
+  if (third !== '') {
+    arrayOfParams.push(third);
+  }
+
+  if (forth !== '') {
+    arrayOfParams.push(forth);
   }
 
   let queryParams = '?' + arrayOfParams.join('&');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,7 +160,7 @@ export const insertStoreResource = (state: NgrxJsonApiStoreResources,
         newState[resource.id] = {
             resource : resource,
             originalResource : resource,
-            state : ResourceState.CREATED,
+            state : ResourceState.IN_SYNC,
             errors : [],
             loading : false
         };


### PR DESCRIPTION
- store is able to hold unsaved changes
- new actions to update resources in the store without sending those updates to the server.
- new service (currently suffixed with V2)
- commit() action to send unsaved changes to server
- rollback() action to undo any unsaved changes
- store holds onto queries (params and results)
- query results are stored as array of resourceIdentifier
- selectQuery method to subscribe to query and transform
resourceIdentifier to actual resources by looking up the resources in
the store.
- errors saved in store (for both queries and resources). read errors
are saved with the query. delete/post/patch errors are saved with the
individual errors.
- queryParams extended by sorting, paging and fields

do not merge, not yet ready, no tests, just proof of concept.