### PR TITLE
WIP: Add queries manually

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -5,7 +5,8 @@ import { Action } from '@ngrx/store';
 import {
   Payload,
   Resource,
-  ResourceIdentifier
+  ResourceIdentifier,
+  ResourceQuery,
 } from './interfaces';
 import { type } from './utils';
 
@@ -27,11 +28,11 @@ export const NgrxJsonApiActionTypes = {
     API_COMMIT_SUCCESS: type('API_COMMIT_SUCCESS'),
     API_COMMIT_FAIL: type('API_COMMIT_FAIL'),
     API_ROLLBACK: type('API_ROLLBACK'),
-    REMOVE_QUERY: type('REMOVE_QUERY'),
-    DELETE_FROM_STATE: type('DELETE_FROM_STATE'),
-    POST_STORE_RESOURCE: type('POST_STORE_RESOURCE'),
+    ADD_QUERY: type('ADD_QUERY'),
+    DELETE_STORE_RESOURCE: type('DELETE_STORE_RESOURCE'),
     PATCH_STORE_RESOURCE: type('PATCH_STORE_RESOURCE'),
-    DELETE_STORE_RESOURCE: type('DELETE_STORE_RESOURCE')
+    POST_STORE_RESOURCE: type('POST_STORE_RESOURCE'),
+    REMOVE_QUERY: type('REMOVE_QUERY'),
 }
 
 export class ApiCommitInitAction implements Action {
@@ -114,19 +115,24 @@ export class ApiUpdateFailAction implements Action {
     constructor(public payload: Payload) { }
 }
 
-export class PostStoreResourceAction implements Action {
-    type = NgrxJsonApiActionTypes.POST_STORE_RESOURCE;
-    constructor(public payload: Resource) { }
-}
-
-export class PatchStoreResourceAction implements Action {
-    type = NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE;
-    constructor(public payload: Resource) { }
+export class AddQueryAction implements Action {
+  type = NgrxJsonApiActionTypes.ADD_QUERY;
+  constructor(public payload: ResourceQuery) { }
 }
 
 export class DeleteStoreResourceAction implements Action {
-    type = NgrxJsonApiActionTypes.DELETE_STORE_RESOURCE;
-    constructor(public payload: ResourceIdentifier) { }
+  type = NgrxJsonApiActionTypes.DELETE_STORE_RESOURCE;
+  constructor(public payload: ResourceIdentifier) { }
+}
+
+export class PatchStoreResourceAction implements Action {
+  type = NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE;
+  constructor(public payload: Resource) { }
+}
+
+export class PostStoreResourceAction implements Action {
+    type = NgrxJsonApiActionTypes.POST_STORE_RESOURCE;
+    constructor(public payload: Resource) { }
 }
 
 export class RemoveQueryAction implements Action {
@@ -151,7 +157,8 @@ export type NgrxJsonApiActions
     | ApiUpdateInitAction
     | ApiUpdateSuccessAction
     | ApiUpdateFailAction
-    | PatchStoreResourceAction
+    | AddQueryAction
     | DeleteStoreResourceAction
+    | PatchStoreResourceAction
     | PostStoreResourceAction
     | RemoveQueryAction

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -28,7 +28,8 @@ export const NgrxJsonApiActionTypes = {
     API_COMMIT_SUCCESS: type('API_COMMIT_SUCCESS'),
     API_COMMIT_FAIL: type('API_COMMIT_FAIL'),
     API_ROLLBACK: type('API_ROLLBACK'),
-    ADD_QUERY: type('ADD_QUERY'),
+    QUERY_STORE_INIT: type('QUERY_STORE_INIT'),
+    QUERY_STORE_SUCCESS: type('QUERY_STORE_SUCCESS'),
     DELETE_STORE_RESOURCE: type('DELETE_STORE_RESOURCE'),
     PATCH_STORE_RESOURCE: type('PATCH_STORE_RESOURCE'),
     POST_STORE_RESOURCE: type('POST_STORE_RESOURCE'),
@@ -115,11 +116,6 @@ export class ApiUpdateFailAction implements Action {
     constructor(public payload: Payload) { }
 }
 
-export class AddQueryAction implements Action {
-  type = NgrxJsonApiActionTypes.ADD_QUERY;
-  constructor(public payload: ResourceQuery) { }
-}
-
 export class DeleteStoreResourceAction implements Action {
   type = NgrxJsonApiActionTypes.DELETE_STORE_RESOURCE;
   constructor(public payload: ResourceIdentifier) { }
@@ -140,6 +136,16 @@ export class RemoveQueryAction implements Action {
     constructor(public payload: string) { }
 }
 
+export class QueryStoreInitAction implements Action {
+  type = NgrxJsonApiActionTypes.QUERY_STORE_INIT;
+  constructor(public payload: ResourceQuery) { }
+}
+
+export class QueryStoreSuccessAction implements Action {
+  type = NgrxJsonApiActionTypes.QUERY_STORE_SUCCESS;
+  constructor(public payload: Payload) { }
+}
+
 export type NgrxJsonApiActions
     = ApiCommitInitAction
     | ApiCommitSuccessAction
@@ -157,8 +163,9 @@ export type NgrxJsonApiActions
     | ApiUpdateInitAction
     | ApiUpdateSuccessAction
     | ApiUpdateFailAction
-    | AddQueryAction
     | DeleteStoreResourceAction
     | PatchStoreResourceAction
     | PostStoreResourceAction
     | RemoveQueryAction
+    | QueryStoreInitAction
+    | QueryStoreSuccessAction

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -30,6 +30,7 @@ import {
   NgrxJsonApiActionTypes,
 } from './actions';
 import { NgrxJsonApi } from './api';
+import { NgrxJsonApiSelectors } from './selectors';
 import {
   NgrxJsonApiStore,
   Payload,
@@ -54,6 +55,7 @@ export class NgrxJsonApiEffects implements OnDestroy {
     private actions$: Actions,
     private jsonApi: NgrxJsonApi,
     private store: Store<any>,
+    private selectors: NgrxJsonApiSelectors<any>,
   ) { }
 
   @Effect() createResource$ = this.actions$
@@ -85,6 +87,16 @@ export class NgrxJsonApiEffects implements OnDestroy {
           query: payload.query
         }))
         .catch(error => Observable.of(new ApiReadFailAction(this.toErrorPayload(payload.query, error))));
+    });
+
+  @Effect() queryStore$ = this.actions$
+    .ofType(NgrxJsonApiActionTypes.QUERY_STORE_INIT)
+    .map<Action, ResourceQuery>(toPayload)
+    .mergeMap((query: ResourceQuery) => {
+      return this.store.let(this.selectors.get$(query))
+      .map(results => Observable.of(new QueryStoreSuccessAction({
+        data: results
+      })));
     });
 
   @Effect() deleteResource$ = this.actions$

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -56,6 +56,13 @@ export interface QueryParams {
     limit?: number
 }
 
+export type QueryType
+    = 'getOne'
+    | 'getMany'
+    | 'update'
+    | 'deleteOne'
+    | 'create'
+
 export interface RelationDefinition {
     relation: string;
     type: string;
@@ -165,11 +172,3 @@ export interface SortingParam {
     api: string;
     direction: Direction;
 }
-
-export type QueryType
-    = 'getOne'
-    | 'getMany'
-    | 'getAll'
-    | 'update'
-    | 'deleteOne'
-    | 'create'

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -130,6 +130,12 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
                 );
                 return newState;
 
+            case NgrxJsonApiActionTypes.ADD_QUERY:
+              // newState = Object.assign({}, state, {
+              //   queries: updateQueryResults(
+              //       state.queries, action.payload.queryId, ...),
+              // })
+
             case NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE:
                 newState = Object.assign({},
                     state, {

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -130,11 +130,14 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
                 );
                 return newState;
 
-            case NgrxJsonApiActionTypes.ADD_QUERY:
-              // newState = Object.assign({}, state, {
-              //   queries: updateQueryResults(
-              //       state.queries, action.payload.queryId, ...),
-              // })
+            case NgrxJsonApiActionTypes.QUERY_STORE_SUCCESS:
+              newState = Object.assign({}, state, {
+                queries: updateQueryResults(
+                    state.queries,
+                    action.payload.query.queryId,
+                    action.payload.jsonApiData),
+              })
+              return newState;
 
             case NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE:
                 newState = Object.assign({},

--- a/src/services.ts
+++ b/src/services.ts
@@ -11,11 +11,11 @@ import {
   ApiReadInitAction,
   ApiUpdateInitAction,
   ApiDeleteInitAction,
-  AddQueryAction,
   DeleteStoreResourceAction,
   PatchStoreResourceAction,
   PostStoreResourceAction,
   RemoveQueryAction,
+  QueryStoreInitAction,
 } from './actions';
 import {
   NgrxJsonApiStore,
@@ -89,7 +89,7 @@ export class NgrxJsonApiService {
       };
       this.store.dispatch(new ApiReadInitAction(payload));
     } else {
-      this.store.dispatch(new AddQueryAction(query));
+      this.store.dispatch(new QueryStoreInitAction(query));
     }
 
   }

--- a/src/services.ts
+++ b/src/services.ts
@@ -11,9 +11,10 @@ import {
   ApiReadInitAction,
   ApiUpdateInitAction,
   ApiDeleteInitAction,
+  AddQueryAction,
   DeleteStoreResourceAction,
-  PostStoreResourceAction,
   PatchStoreResourceAction,
+  PostStoreResourceAction,
   RemoveQueryAction,
 } from './actions';
 import {
@@ -21,7 +22,7 @@ import {
   Payload,
   QueryType,
   Resource,
-  ResourceDefinition
+  ResourceDefinition,
   ResourceIdentifier,
   ResourceQuery,
   ResourceQueryHandle,
@@ -50,9 +51,9 @@ export class NgrxJsonApiService {
     this.store.select(selectors.storeLocation).subscribe(it => this.storeSnapshot = it as NgrxJsonApiStore);
   }
 
-  public findOne(query: ResourceQuery) : ResourceQueryHandle<Resource> {
+  public findOne(query: ResourceQuery, fromServer: boolean = true) : ResourceQueryHandle<Resource> {
     query.queryType = "getOne";
-    this.findInternal(query);
+    this.findInternal(query, fromServer);
 
     return {
       results : this.selectResults(query.queryId).map(it => {
@@ -68,9 +69,9 @@ export class NgrxJsonApiService {
     }
   }
 
-  public findMany(query: ResourceQuery) : ResourceQueryHandle<Array<Resource>> {
+  public findMany(query: ResourceQuery, fromServer: boolean = true) : ResourceQueryHandle<Array<Resource>> {
     query.queryType = "getMany";
-    this.findInternal(query);
+    this.findInternal(query, fromServer);
     return {
       results : this.selectResults(query.queryId),
       unsubscribe : () => this.removeQuery(query.queryId)
@@ -81,11 +82,16 @@ export class NgrxJsonApiService {
     this.store.dispatch(new RemoveQueryAction(queryId));
   }
 
-  private findInternal(query: ResourceQuery){
-    let payload : Payload = {
-      query: query
-    };
-    this.store.dispatch(new ApiReadInitAction(payload));
+  private findInternal(query: ResourceQuery, fromServer: boolean = true){
+    if (fromServer) {
+      let payload : Payload = {
+        query: query
+      };
+      this.store.dispatch(new ApiReadInitAction(payload));
+    } else {
+      this.store.dispatch(new AddQueryAction(query));
+    }
+
   }
 
   /**


### PR DESCRIPTION
Right now, to add a query one has to send requests to the API using `service.findOne` or `service.findMany`. Sometimes, one needs to fetch data from the store without sending requests to the API. In typical redux/ngrx, we use selectors to do such thing. However, since we have a "query api" ready to use, we can add queries manually and then the results can be extracted from this query.

This PR is not finished!