### PR TITLE
Change operations status from bool to number

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,7 +24,7 @@ module.exports = function(karma) {
         mime: {
           'text/x-typescript': ['ts','tsx']
         },
-        reporters: ['mocha', 'coverage'],
+        reporters: ['jasmine-diff', 'mocha', 'coverage'],
 
         coverageReporter: {
             dir: 'coverage/',

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "^1.1.1",
     "karma-jasmine": "^1.1.0",
+    "karma-jasmine-diff-reporter": "^0.6.3",
     "karma-mocha-reporter": "^2.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.8.0",

--- a/spec/reducers.spec.ts
+++ b/spec/reducers.spec.ts
@@ -49,21 +49,26 @@ describe('NgrxJsonApiReducer', () => {
     deepFreeze(state);
 
     describe('API_CREATE_INIT action', () => {
-        it('should change isCreating status', () => {
+        it('should add 1 to isCreating', () => {
             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateInitAction({}));
-            expect(newState.isCreating).toBe(true);
+            expect(newState.isCreating).toBe(1);
         });
     });
 
     describe('API_READ_INIT action', () => {
+        let newState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+            query: {
+                id: '1',
+                type: 'Article',
+                queryId: '111'
+            }
+        }));
+
+        it('should change isReading status by adding 1', () => {
+            expect(newState.isReading - state.isReading).toBe(1);
+        });
+
         it('should update the storeQueries', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-                query: {
-                    id: '1',
-                    type: 'Article',
-                    queryId: '111'
-                }
-            }));
             expect(newState.queries['111'].query.type).toEqual('Article');
             expect(newState.queries['111'].query.id).toEqual('1');
         });
@@ -84,23 +89,23 @@ describe('NgrxJsonApiReducer', () => {
     });
 
     describe('API_UPDATE_INIT action', () => {
-        it('should set isUpdating status to true', () => {
+        it('should add 1 to isUpdating', () => {
             let newState = NgrxJsonApiStoreReducer(state, new ApiUpdateInitAction({}));
-            expect(newState.isUpdating).toBe(true);
+            expect(newState.isUpdating).toBe(1);
         });
     });
 
     describe('API_DELETE_INIT action', () => {
-        it('should set isDeleting status to true', () => {
+        it('should add 1 isDeleting', () => {
             let newState = NgrxJsonApiStoreReducer(state, new ApiDeleteInitAction({}));
-            expect(newState.isDeleting).toBe(true);
+            expect(newState.isDeleting).toBe(1);
         });
     });
 
     describe('API_CREATE_SUCCESS action', () => {
-        it('should set isCreating status to false', () => {
+        it('should subtract 1 from isCreating', () => {
             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({}));
-            expect(newState.isCreating).toBe(false);
+            expect(state.isCreating - newState.isCreating).toBe(1);
         });
 
         it('should add data to the store', () => {
@@ -117,19 +122,15 @@ describe('NgrxJsonApiReducer', () => {
             type: 'Article',
             id: '1'
         }
-        it('should set isReading status to false', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-                jsonApiData: testPayload,
-                query: query
-            }));
-            expect(newState.isReading).toBe(false);
+        let newState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+          jsonApiData: testPayload,
+          query: query
+        }));
+        it('should subtract 1 from isReading', () => {
+            expect(state.isReading - newState.isReading).toBe(1);
         });
 
         it('should add data to the store', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-                jsonApiData: testPayload,
-                query: query
-            }));
             expect(newState.data['Article']['1']).toBeDefined();
         })
 
@@ -156,105 +157,111 @@ describe('NgrxJsonApiReducer', () => {
             type: 'Article',
             id: '1'
         }
-        it('should set isUpdating status to false', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiUpdateSuccessAction({
-                jsonApiData: testPayload,
-            }));
-            expect(newState.isUpdating).toBe(false);
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+          jsonApiData: testPayload,
+          query: {
+            id: '1',
+            type: 'Article',
+            queryId: '111'
+          }
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiUpdateSuccessAction({
+          jsonApiData: {
+            data: {
+              type: 'Article',
+              id: '1',
+              attributes: {
+                title: 'bla bla bla'
+              }
+            }
+          },
+        }));
+
+        it('should subtract 1 from isUpdating', () => {
+            expect(state.isUpdating - newState.isUpdating).toBe(1);
         });
 
         it('should add data to the store', () => {
-            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-                jsonApiData: testPayload,
-                query: {
-                    id: '1',
-                    type: 'Article',
-                    queryId: '111'
-                }
-            }));
-            let newState = NgrxJsonApiStoreReducer(tempState, new ApiUpdateSuccessAction({
-                jsonApiData: {
-                    data: {
-                        type: 'Article',
-                        id: '1',
-                        attributes: {
-                            title: 'bla bla bla'
-                        }
-                    }
-                },
-            }));
             expect(newState.data['Article']['1'].resource.attributes.title).toEqual('bla bla bla');
         })
     });
 
     describe('API_DELETE_SUCCESS', () => {
-        it('should set isDeleting status to false', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiDeleteSuccessAction({
-                query: {
-                    type: 'Article'
-                }
-            }));
-            expect(newState.isDeleting).toBe(false);
+
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+          jsonApiData: testPayload,
+          query: {
+            id: '1',
+            type: 'Article',
+            queryId: '111'
+          }
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiDeleteSuccessAction({
+          query: {
+            type: 'Article'
+          }
+        }));
+
+        it('should subtract 1 from isDeleting', () => {
+            expect(state.isDeleting - newState.isDeleting).toBe(1);
         });
 
         it('should remove resources from the store', () => {
-            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-                jsonApiData: testPayload,
-                query: {
-                    id: '1',
-                    type: 'Article',
-                    queryId: '111'
-                }
-            }));
-            let newState = NgrxJsonApiStoreReducer(tempState, new ApiDeleteSuccessAction({
-                query: {
-                    type: 'Article'
-                }
-            }));
             expect(newState.data['Article']).toEqual({});
         });
     });
 
     describe('API_CREATE_FAIL', () => {
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
+            jsonApiData: testPayload
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiCreateFailAction({
+            jsonApiData: {
+                errors: [
+                    'permission denied'
+                ]
+            },
+            query: {
+                id: '1',
+                type: 'Article',
+            }
+        }));
         it('should add the errors to the resource', () => {
-            let tempState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
-                jsonApiData: testPayload
-            }));
-            let newState = NgrxJsonApiStoreReducer(tempState, new ApiCreateFailAction({
-                jsonApiData: {
-                    errors: [
-                        'permission denied'
-                    ]
-                },
-                query: {
-                    id: '1',
-                    type: 'Article',
-                }
-            }));
             expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
         });
+
+        it('should subtract 1 from isCreating', () => {
+            expect(tempState.isCreating - newState.isCreating).toBe(1);
+        });
+
     });
 
     describe('API_READ_FAIL', () => {
-        it('should add the errors to the resource', () => {
-            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-                query: {
-                    id: '1',
-                    type: 'Article',
-                    queryId: '111'
-                }
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+            query: {
+                id: '1',
+                type: 'Article',
+                queryId: '111'
+            }
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadFailAction({
+            jsonApiData: {
+                errors: ['permission denied']
+            },
+            query: {
+                queryId: '111',
+                id: '1',
+                type: 'Article',
             }));
-            let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadFailAction({
-                jsonApiData: {
-                    errors: ['permission denied']
-                },
-                query: {
-                    queryId: '111',
-                    id: '1',
-                    type: 'Article',
-                }));
+
+        it('should add the errors to the resource', () => {
             expect(newState.queries['111'].errors[0]).toEqual('permission denied');
         });
+
+        it('should subtract 1 from isReading', () => {
+            expect(tempState.isReading - newState.isReading).toBe(1);
+        });
+
     });
 
     describe('API_UPDATE_FAIL action', () => {
@@ -280,8 +287,8 @@ describe('NgrxJsonApiReducer', () => {
                 type: 'Article',
             }
         }));
-        it('should set isUpdating status to false', () => {
-            expect(newState.isUpdating).toBe(false);
+        it('should subtract 1 from isUpdating', () => {
+            expect(tempState2.isUpdating - newState.isUpdating).toBe(1);
         });
 
         it('should add errors to the resource', () => {
@@ -312,8 +319,8 @@ describe('NgrxJsonApiReducer', () => {
                 type: 'Article',
             }
         }));
-        it('should set isDeleting status to false', () => {
-            expect(newState.isDeleting).toBe(false);
+        it('should subtract 1 from isDeleting', () => {
+            expect(tempState2.isDeleting - newState.isDeleting).toBe(1);
         });
 
         it('should add errors to the resource', () => {
@@ -360,18 +367,19 @@ describe('NgrxJsonApiReducer', () => {
 
         it('should not update state on second identical post', () => {
             let action = new PostStoreResourceAction(
-                { type: 'Article', id: '1', attributes : {title : 'sample title'} }
+                { type: 'Article', id: '1', attributes: { title: 'sample title' } }
             );
             let newState = NgrxJsonApiStoreReducer(state, action);
             let newState2 = NgrxJsonApiStoreReducer(newState, action);
             expect(newState.data['Article']['1']).toBeDefined();
             expect(newState2.data['Article']['1']).toBeDefined();
-            expect(newState2 === newState).toBeTruthy();
+            expect(newState).toBe(newState2);
+            // expect(newState2 === newState).toBeTruthy();
         });
 
         it('should not update state on second identical patch', () => {
             let action = new PatchStoreResourceAction(
-                { type: 'Article', id: '1', attributes : {title : 'sample title', description : 'test description'} }
+                { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'test description' } }
             );
             let newState = NgrxJsonApiStoreReducer(state, action);
             let newState2 = NgrxJsonApiStoreReducer(newState, action);
@@ -382,10 +390,10 @@ describe('NgrxJsonApiReducer', () => {
 
         it('should not update state on second partial patch', () => {
             let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
-                { type: 'Article', id: '1', attributes : {title : 'sample title', description : 'sample description'} }
+                { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'sample description' } }
             ));
             let newState2 = NgrxJsonApiStoreReducer(newState, new PatchStoreResourceAction(
-                { type: 'Article', id: '1', attributes : {title : 'sample title'} }
+                { type: 'Article', id: '1', attributes: { title: 'sample title' } }
             ));
             expect(newState.data['Article']['1'].resource.attributes.title).toEqual("sample title");
             expect(newState.data['Article']['1'].resource.attributes.description).toEqual("sample description");
@@ -396,9 +404,9 @@ describe('NgrxJsonApiReducer', () => {
     });
 
     describe('API_COMMIT_INIT action', () => {
-        it('should change isCommitting to true', () => {
+        it('should add 1 to isCommitting', () => {
             let newState = NgrxJsonApiStoreReducer(state, new ApiCommitInitAction());
-            expect(newState.isCommitting).toBe(true);
+            expect(newState.isCommitting - state.isCommitting).toBe(1);
         });
     });
 
@@ -407,10 +415,10 @@ describe('NgrxJsonApiReducer', () => {
     });
 
     describe('ALL OTHER ACTIONS', () => {
-      it('should return the state', () => {
-        let newState = NgrxJsonApiStoreReducer(state, {type: 'RANDOM_ACTION'});
-        expect(newState).toEqual(state);
-      });
+        it('should return the state', () => {
+            let newState = NgrxJsonApiStoreReducer(state, { type: 'RANDOM_ACTION' });
+            expect(newState).toEqual(state);
+        });
     });
 
 });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,11 +25,11 @@ export interface FilteringParam {
 export interface NgrxJsonApiStore {
     data: NgrxJsonApiStoreData;
     queries: NgrxJsonApiStoreQueries;
-    isCreating: boolean;
-    isReading: boolean;
-    isUpdating: boolean;
-    isDeleting: boolean;
-    isCommitting: boolean;
+    isCreating: number;
+    isReading: number;
+    isUpdating: number;
+    isDeleting: number;
+    isCommitting: number;
 }
 
 export interface NgrxJsonApiModuleConfig {
@@ -41,6 +41,13 @@ export interface NgrxJsonApiModuleConfig {
 export type NgrxJsonApiStoreResources = { [id: string]: ResourceStore };
 export type NgrxJsonApiStoreData = { [key: string]: NgrxJsonApiStoreResources };
 export type NgrxJsonApiStoreQueries = { [key: string]: ResourceQueryStore };
+
+export type OperationType
+        = 'CREATING'
+        | 'UPDATING'
+        | 'DELETING'
+        | 'READING'
+        | false
 
 export interface Payload {
     jsonApiData?: Document;
@@ -62,6 +69,7 @@ export type QueryType
     | 'update'
     | 'deleteOne'
     | 'create'
+
 
 export interface RelationDefinition {
     relation: string;
@@ -159,9 +167,9 @@ export interface ResourceStore {
      */
     persistedResource: Resource;
     /**
-     * True if any kind of operation is executed (post, patch, delete).
+     * One of the operation types: reading, creating, updating or deleting.
      */
-    loading?: boolean;
+    loading?: OperationType;
     /**
      * Errors received from the server after attempting to store the resource.
      */

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -1,8 +1,7 @@
-import * as _ from 'lodash';
 import { Action, ActionReducer } from '@ngrx/store';
 
 import {
-  NgrxJsonApiActionTypes
+    NgrxJsonApiActionTypes
 } from './actions';
 import {
     ResourceQuery,
@@ -22,14 +21,14 @@ import {
     updateResourceErrors,
 } from './utils';
 
-export const initialNgrxJsonApiState = {
-    isCreating: false,
-    isReading: false,
-    isUpdating: false,
-    isDeleting: false,
-    isCommitting : false,
+export const initialNgrxJsonApiState: NgrxJsonApiStore = {
+    isCreating: 0,
+    isReading: 0,
+    isUpdating: 0,
+    isDeleting: 0,
+    isCommitting: 0,
     data: {},
-    queries : {}
+    queries: {}
 };
 
 export const NgrxJsonApiStoreReducer: ActionReducer<any> =
@@ -39,132 +38,136 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
         // console.log("reduce", state, action);
 
         switch (action.type) {
-            case NgrxJsonApiActionTypes.API_CREATE_INIT:{
-                return Object.assign({}, state, { 'isCreating': true });
+            case NgrxJsonApiActionTypes.API_CREATE_INIT: {
+                return Object.assign({}, state, { isCreating: state['isCreating'] + 1 });
             }
-            case NgrxJsonApiActionTypes.API_READ_INIT:{
-                newState = Object.assign({}, state, { 'isReading': true });
+            case NgrxJsonApiActionTypes.API_READ_INIT: {
                 let query = action.payload.query as ResourceQuery;
                 // FIXME: handle queries with no queryId
-                if(query.queryId){
+                if (query.queryId) {
                     newState = Object.assign({}, state, {
-                        queries: updateQueryParams( state.queries, query),
+                        queries: updateQueryParams(state.queries, query),
+                        isReading: state.isReading + 1
                     });
                 }
                 return newState;
             }
-            case NgrxJsonApiActionTypes.REMOVE_QUERY:{
+            case NgrxJsonApiActionTypes.REMOVE_QUERY: {
                 let queryId = action.payload as string;
                 newState = Object.assign({}, state, {
-                    queries: removeQuery( state.queries, queryId),
+                    queries: removeQuery(state.queries, queryId),
                 });
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_UPDATE_INIT:{
-                return Object.assign({}, state, { 'isUpdating': true });
+            case NgrxJsonApiActionTypes.API_UPDATE_INIT: {
+                return Object.assign({}, state, { isUpdating: state['isUpdating'] + 1 });
             }
-            case NgrxJsonApiActionTypes.API_DELETE_INIT:{
-                return Object.assign({}, state, { 'isDeleting': true });
+            case NgrxJsonApiActionTypes.API_DELETE_INIT: {
+                return Object.assign({}, state, { isDeleting: state['isDeleting'] + 1 });
             }
-            case NgrxJsonApiActionTypes.API_CREATE_SUCCESS:{
+            case NgrxJsonApiActionTypes.API_CREATE_SUCCESS: {
                 newState = Object.assign({},
                     state, {
                         data: updateStoreResources(
-                          state.data, action.payload.jsonApiData),
-                    },
-                    { 'isCreating': false }
+                            state.data, action.payload.jsonApiData),
+                        isCreating: state.isCreating - 1
+                    }
                 );
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_READ_SUCCESS:{
+            case NgrxJsonApiActionTypes.API_READ_SUCCESS: {
                 newState = Object.assign({},
                     state, {
                         data: updateStoreResources(
-                          state.data, action.payload.jsonApiData),
+                            state.data, action.payload.jsonApiData),
                         queries: updateQueryResults(
                             state.queries, action.payload.query.queryId, action.payload.jsonApiData),
-                    },
-                    { 'isReading': false }
+                        isReading: state.isReading - 1
+                    }
                 );
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_UPDATE_SUCCESS:{
+            case NgrxJsonApiActionTypes.API_UPDATE_SUCCESS: {
                 newState = Object.assign(
                     {},
                     state, {
                         data: updateStoreResources(
-                          state.data, action.payload.jsonApiData),
-                    },
-                    { 'isUpdating': false }
+                            state.data, action.payload.jsonApiData),
+                        isUpdating: state.isUpdating - 1
+                    }
                 );
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_DELETE_SUCCESS:{
+            case NgrxJsonApiActionTypes.API_DELETE_SUCCESS: {
                 newState = Object.assign({}, state,
-                    { data: deleteStoreResources(state.data, action.payload.query) },
-                    { 'isDeleting': false });
+                    {
+                        data: deleteStoreResources(state.data, action.payload.query),
+                        isDeleting: state.isDeleting - 1
+                    });
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_CREATE_FAIL:{
+            case NgrxJsonApiActionTypes.API_CREATE_FAIL: {
                 newState = Object.assign({}, state, {
-                  data: updateResourceErrors(state.data, action.payload.query, action.payload.jsonApiData),
-                  'isCreating': false }
-                );
-                return newState;
-            }
-            case NgrxJsonApiActionTypes.API_READ_FAIL:{
-                newState = Object.assign({}, state, {
-                  queries: updateQueryErrors(state.queries, action.payload.query.queryId, action.payload.jsonApiData),
-                  'isReading': false
+                    data: updateResourceErrors(state.data, action.payload.query, action.payload.jsonApiData),
+                    isCreating: state.isCreating - 1
                 });
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_UPDATE_FAIL:{
+            case NgrxJsonApiActionTypes.API_READ_FAIL: {
                 newState = Object.assign({}, state, {
-                  data: updateResourceErrors(state.data, action.payload.query, action.payload.jsonApiData),
-                  'isUpdating': false }
+                    queries: updateQueryErrors(state.queries, action.payload.query.queryId, action.payload.jsonApiData),
+                    isReading: state.isReading - 1
+                });
+                return newState;
+            }
+            case NgrxJsonApiActionTypes.API_UPDATE_FAIL: {
+                newState = Object.assign({}, state, {
+                    data: updateResourceErrors(state.data, action.payload.query, action.payload.jsonApiData),
+                    isUpdating: state.isUpdating - 1
+                }
                 );
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_DELETE_FAIL:{
+            case NgrxJsonApiActionTypes.API_DELETE_FAIL: {
                 newState = Object.assign({}, state, {
-                  data: updateResourceErrors(state.data, action.payload.query, action.payload.jsonApiData),
-                  'isDeleting': false }
+                    data: updateResourceErrors(state.data, action.payload.query, action.payload.jsonApiData),
+                    isDeleting: state.isDeleting - 1
+                }
                 );
                 return newState;
             }
-            case NgrxJsonApiActionTypes.QUERY_STORE_SUCCESS:{
-              newState = Object.assign({}, state, {
-                queries: updateQueryResults(
-                    state.queries,
-                    action.payload.query.queryId,
-                    action.payload.jsonApiData),
-              })
-              return newState;
+            case NgrxJsonApiActionTypes.QUERY_STORE_SUCCESS: {
+                newState = Object.assign({}, state, {
+                    queries: updateQueryResults(
+                        state.queries,
+                        action.payload.query.queryId,
+                        action.payload.jsonApiData),
+                })
+                return newState;
             }
-            case NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE:{
+            case NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE: {
                 let updatedData = updateOrInsertResource(state.data, action.payload, false, false);
-                if(updatedData !== state.data) {
+                if (updatedData !== state.data) {
                     newState = Object.assign({},
                         state, {
                             data: updatedData
                         }
                     );
                     return newState;
-                }else{
+                } else {
                     return state;
                 }
             }
-            case NgrxJsonApiActionTypes.POST_STORE_RESOURCE:{
+            case NgrxJsonApiActionTypes.POST_STORE_RESOURCE: {
                 let updatedData = updateOrInsertResource(state.data, action.payload, false, true)
-                if(updatedData !== state.data) {
+                if (updatedData !== state.data) {
                     newState = Object.assign({},
                         state, {
                             data: updatedData
                         }
                     );
                     return newState;
-                }else{
+                } else {
                     return state;
                 }
             }
@@ -178,7 +181,7 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
                 return newState;
             }
             case NgrxJsonApiActionTypes.API_COMMIT_INIT: {
-                newState = Object.assign({}, state, {'isCommitting': true});
+                newState = Object.assign({}, state, { isCommitting: state.isCommitting + 1 });
                 return newState;
             }
             case NgrxJsonApiActionTypes.API_COMMIT_SUCCESS:
@@ -189,10 +192,10 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
                 for (let commitAction of actions) {
                     newState = NgrxJsonApiStoreReducer(newState, commitAction);
                 }
-                newState = Object.assign({}, newState, {isCommitting: false});
+                newState = Object.assign({}, newState, { isCommitting: state['isCommitting'] - 1 });
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_ROLLBACK:{
+            case NgrxJsonApiActionTypes.API_ROLLBACK: {
                 newState = Object.assign({},
                     state, {
                         data: rollbackStoreResources(state.data)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
     NgrxJsonApiStoreData,
     NgrxJsonApiStoreResources,
     NgrxJsonApiStoreQueries,
+    OperationType,
     QueryParams,
     RelationDefinition,
     Resource,
@@ -316,7 +317,6 @@ export const updateOrInsertResource = (state: NgrxJsonApiStoreData,
         newState[resource.type] = {};
         newState[resource.type] = insertStoreResource(newState[resource.type], resource, fromServer);
         return newState;
-
     } else if (_.isUndefined(state[resource.type][resource.id]) || override) {
         let updatedTypeState = insertStoreResource(state[resource.type], resource, fromServer);
         if(updatedTypeState !== state[resource.type]) {
@@ -347,7 +347,7 @@ export const updateOrInsertResource = (state: NgrxJsonApiStoreData,
  * @returns {NgrxJsonApiStoreData}
  */
 export const updateResourceState = (state: NgrxJsonApiStoreData,
-    resourceId: ResourceIdentifier, resourceState? : ResourceState, loading? : boolean): NgrxJsonApiStoreData => {
+    resourceId: ResourceIdentifier, resourceState? : ResourceState, loading? : OperationType): NgrxJsonApiStoreData => {
     if (_.isUndefined(state[resourceId.type]) || _.isUndefined(state[resourceId.type][resourceId.id])) {
         return state;
     }


### PR DESCRIPTION
Previously the store operations status (isCreating, isUpdating ...)
were booleans. This isn't useful to know for example how many update
operations are being carried out. Therefore, each status was changed to
a number so `isCreating --> 2` means 2 creation operations are being
carried out.