### PR TITLE
Feat: Denormalization (WIP)

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "source-map-loader": "^0.1.5",
     "ts-helpers": "1.1.2",
     "tslint": "^4.0.2",
-    "typescript": "2.1.1",
+    "typescript": "2.0.10",
     "webpack": "^2.2.0-rc.0",
     "webpack-bundle-size-analyzer": "^2.0.2",
     "zone.js": "0.7.3"

--- a/spec/actions.spec.ts
+++ b/spec/actions.spec.ts
@@ -19,9 +19,9 @@ import {
     ApiDeleteInitAction,
     ApiDeleteSuccessAction,
     ApiDeleteFailAction,
-    ApiCommitInitAction,
-    ApiCommitSuccessAction,
-    ApiCommitFailAction,
+    ApiApplyInitAction,
+    ApiApplySuccessAction,
+    ApiApplyFailAction,
     ApiRollbackAction,
     QueryStoreInitAction,
     QueryStoreSuccessAction,
@@ -34,6 +34,10 @@ import {
 describe('Json Api Actions', () => {
 
     let actions;
+
+    it('should have a fixed number of actions', () => {
+      expect(Object.keys(NgrxJsonApiActionTypes).length).toEqual(22);
+    });
 
     it('should have an api create init action', () => {
         expect(NgrxJsonApiActionTypes.API_CREATE_INIT).toBeDefined();
@@ -96,18 +100,18 @@ describe('Json Api Actions', () => {
     });
 
     it('should have an api commit init action', () => {
-        expect(NgrxJsonApiActionTypes.API_COMMIT_INIT).toBeDefined();
-        expect(NgrxJsonApiActionTypes.API_COMMIT_INIT).toBe('API_COMMIT_INIT');
+        expect(NgrxJsonApiActionTypes.API_APPLY_INIT).toBeDefined();
+        expect(NgrxJsonApiActionTypes.API_APPLY_INIT).toBe('API_APPLY_INIT');
     });
 
     it('should have an api commit success action', () => {
-        expect(NgrxJsonApiActionTypes.API_COMMIT_SUCCESS).toBeDefined();
-        expect(NgrxJsonApiActionTypes.API_COMMIT_SUCCESS).toBe('API_COMMIT_SUCCESS');
+        expect(NgrxJsonApiActionTypes.API_APPLY_SUCCESS).toBeDefined();
+        expect(NgrxJsonApiActionTypes.API_APPLY_SUCCESS).toBe('API_APPLY_SUCCESS');
     });
 
     it('should have an api commit fail action', () => {
-        expect(NgrxJsonApiActionTypes.API_COMMIT_FAIL).toBeDefined();
-        expect(NgrxJsonApiActionTypes.API_COMMIT_FAIL).toBe('API_COMMIT_FAIL');
+        expect(NgrxJsonApiActionTypes.API_APPLY_FAIL).toBeDefined();
+        expect(NgrxJsonApiActionTypes.API_APPLY_FAIL).toBe('API_APPLY_FAIL');
     });
 
     it('should have a query store init action', () => {
@@ -212,21 +216,21 @@ describe('Json Api Actions', () => {
         expect(action.payload).toEqual({});
     });
 
-    it('should generate an api commit init action using ApiCommitInit', () => {
-      let action = new ApiCommitInitAction({});
-        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_COMMIT_INIT);
+    it('should generate an api commit init action using ApiApplyInit', () => {
+      let action = new ApiApplyInitAction({});
+        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_INIT);
+        expect(action.payload).not.toBeDefined();
+    });
+
+    it('should generate an api commit success action using ApiApplySuccess', () => {
+      let action = new ApiApplySuccessAction({});
+        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_SUCCESS);
         expect(action.payload).toEqual({});
     });
 
-    it('should generate an api commit success action using ApiCommitSuccess', () => {
-      let action = new ApiCommitSuccessAction({});
-        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_COMMIT_SUCCESS);
-        expect(action.payload).toEqual({});
-    });
-
-    it('should generate an api commit fail action using ApiCommitFail', () => {
-      let action = new ApiCommitFailAction({});
-        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_COMMIT_FAIL);
+    it('should generate an api commit fail action using ApiApplyFail', () => {
+      let action = new ApiApplyFailAction({});
+        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_FAIL);
         expect(action.payload).toEqual({});
     });
 

--- a/spec/pipes.spec.ts
+++ b/spec/pipes.spec.ts
@@ -1,0 +1,134 @@
+import {
+    async,
+    inject,
+    fakeAsync,
+    tick,
+    TestBed
+} from '@angular/core/testing';
+
+import { Http, HttpModule } from '@angular/http';
+
+import { Store, StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+
+import { NgrxJsonApi } from '../src/api';
+import { NgrxJsonApiService } from '../src/services';
+import { NgrxJsonApiSelectors } from '../src/selectors';
+import { NgrxJsonApiEffects } from '../src/effects';
+import {
+    DenormaliseResourcePipe,
+    GetResourcePipe,
+    SelectResourcePipe,
+    SelectResourceStorePipe,
+} from '../src/pipes';
+
+import {
+    initialNgrxJsonApiState,
+    NgrxJsonApiStoreReducer,
+} from '../src/reducers';
+
+import {
+    NGRX_JSON_API_CONFIG,
+    apiFactory,
+    selectorsFactory,
+    serviceFactory,
+} from '../src/module';
+
+import { updateStoreResources } from '../src/utils';
+
+import {
+    testPayload,
+    resourceDefinitions
+} from './test_utils';
+
+describe('NgrxJsonApiService', () => {
+    let pipe;
+
+    beforeEach(() => {
+        let store = {
+            api: Object.assign({}, initialNgrxJsonApiState, {
+                data: updateStoreResources({}, testPayload),
+            }, )
+        };
+        TestBed.configureTestingModule({
+            imports: [
+                HttpModule,
+                EffectsModule.run(NgrxJsonApiEffects),
+                // EffectsModule.run(NgrxJsonApiEffects),
+                StoreModule.provideStore({ api: NgrxJsonApiStoreReducer }, store),
+            ],
+            providers: [
+                {
+                    provide: NgrxJsonApi,
+                    useFactory: apiFactory,
+                    deps: [Http, NGRX_JSON_API_CONFIG]
+                },
+                {
+                    provide: NgrxJsonApiService,
+                    useFactory: serviceFactory,
+                    deps: [Store, NgrxJsonApiSelectors]
+                },
+                {
+                    provide: NgrxJsonApiSelectors,
+                    useFactory: selectorsFactory,
+                    deps: [NGRX_JSON_API_CONFIG]
+                },
+                {
+                    provide: NGRX_JSON_API_CONFIG,
+                    useValue: {
+                        storeLocation: 'api',
+                        resourceDefinitions: resourceDefinitions
+                    }
+                },
+                DenormaliseResourcePipe,
+                GetResourcePipe,
+                SelectResourcePipe,
+                SelectResourceStorePipe,
+            ],
+        })
+    });
+
+
+    describe('GetResourcePipe', () => {
+        beforeEach(inject([GetResourcePipe], (p) => {
+            pipe = p;
+        }));
+
+    });
+
+    describe('SelectResourcePipe', () => {
+        beforeEach(inject([SelectResourcePipe], (p) => {
+            pipe = p;
+        }));
+
+    });
+
+    describe('SelectResourceStorePipe', () => {
+        beforeEach(inject([SelectResourceStorePipe], (p) => {
+            pipe = p;
+        }));
+
+    });
+
+    describe('DenormaliseResourcePipe', () => {
+
+        beforeEach(inject([DenormaliseResourcePipe], (p) => {
+            pipe = p;
+        }));
+
+        it('should denormalise a Resource', () => {
+            let query = {
+                id: '1',
+                type: 'Article',
+                queryType: 'getOne',
+                queryId: '22'
+            }
+            let resourceStore = pipe.service.findOne(query, false)
+                .results
+            let denormalised = pipe.transform(resourceStore);
+            denormalised.subscribe(it => {
+                expect(_.get(it, 'relationships.author.reference')).toBeDefined();
+            });
+        });
+    });
+});

--- a/spec/pipes.spec.ts
+++ b/spec/pipes.spec.ts
@@ -123,7 +123,7 @@ describe('NgrxJsonApiService', () => {
                 queryType: 'getOne',
                 queryId: '22'
             }
-            let resourceStore = pipe.service.findOne(query, false)
+            let resourceStore = pipe.service.findOne(query, false, true)
                 .results
             let denormalised = pipe.transform(resourceStore);
             denormalised.subscribe(it => {

--- a/spec/reducers.spec.ts
+++ b/spec/reducers.spec.ts
@@ -14,9 +14,9 @@ import {
     initialNgrxJsonApiState
 } from '../src/reducers';
 import {
-    ApiCommitInitAction,
-    ApiCommitSuccessAction,
-    ApiCommitFailAction,
+    ApiApplyInitAction,
+    ApiApplySuccessAction,
+    ApiApplyFailAction,
     ApiCreateInitAction,
     ApiCreateSuccessAction,
     ApiCreateFailAction,
@@ -404,14 +404,14 @@ describe('NgrxJsonApiReducer', () => {
         });
     });
 
-    describe('API_COMMIT_INIT action', () => {
-        it('should add 1 to isCommitting', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiCommitInitAction());
-            expect(newState.isCommitting - state.isCommitting).toBe(1);
+    describe('API_APPLY_INIT action', () => {
+        it('should add 1 to isApplying', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiApplyInitAction());
+            expect(newState.isApplying - state.isApplying).toBe(1);
         });
     });
 
-    describe('API_COMMIT/SUCCESS_FAIL actions', () => {
+    describe('API_APPLY/SUCCESS_FAIL actions', () => {
 
     });
 

--- a/spec/reducers.spec.ts
+++ b/spec/reducers.spec.ts
@@ -1,426 +1,425 @@
-// import {
-//     async,
-//     inject,
-//     fakeAsync,
-//     TestBed
-// } from '@angular/core/testing';
+import {
+    async,
+    inject,
+    fakeAsync,
+    TestBed
+} from '@angular/core/testing';
+
+let deepFreeze = require('deep-freeze');
+
+import _ = require('lodash');
 //
-// let deepFreeze = require('deep-freeze');
-//
-// import _ = require('lodash');
-// //
-// import {
-//     NgrxJsonApiStoreReducer,
-//     initialNgrxJsonApiState
-// } from '../src/reducers';
-// import {
-//     ApiCommitInitAction,
-//     ApiCommitSuccessAction,
-//     ApiCommitFailAction,
-//     ApiCreateInitAction,
-//     ApiCreateSuccessAction,
-//     ApiCreateFailAction,
-//     ApiUpdateInitAction,
-//     ApiUpdateSuccessAction,
-//     ApiUpdateFailAction,
-//     ApiReadInitAction,
-//     ApiReadSuccessAction,
-//     ApiReadFailAction,
-//     ApiDeleteInitAction,
-//     ApiDeleteSuccessAction,
-//     ApiDeleteFailAction,
-//     ApiRollbackAction,
-//     NgrxJsonApiActionTypes,
-//     PatchStoreResourceAction,
-//     PostStoreResourceAction,
-//     RemoveQueryAction,
-//     QueryStoreSuccessAction,
-// } from '../src/actions';
-// import {
-//     NgrxJsonApiStore
-// } from '../src/interfaces';
-//
-// import { testPayload } from './test_utils';
-//
-// describe('NgrxJsonApiReducer', () => {
-//
-//     let state = initialNgrxJsonApiState;
-//
-//     deepFreeze(state);
-//
-//     describe('API_CREATE_INIT action', () => {
-//         it('should add 1 to isCreating', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateInitAction({}));
-//             expect(newState.isCreating).toBe(1);
-//         });
-//     });
-//
-//     describe('API_READ_INIT action', () => {
-//         let newState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-//             query: {
-//                 id: '1',
-//                 type: 'Article',
-//                 queryId: '111'
-//             }
-//         }));
-//
-//         it('should change isReading status by adding 1', () => {
-//             expect(newState.isReading - state.isReading).toBe(1);
-//         });
-//
-//         it('should update the storeQueries', () => {
-//             expect(newState.queries['111'].query.type).toEqual('Article');
-//             expect(newState.queries['111'].query.id).toEqual('1');
-//         });
-//     });
-//
-//     describe('REMOVE_QUERY action', () => {
-//         it('should remove query given a queryId', () => {
-//             let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-//                 query: {
-//                     id: '1',
-//                     type: 'Article',
-//                     queryId: '111'
-//                 }
-//             }));
-//             let newState = NgrxJsonApiStoreReducer(tempState, new RemoveQueryAction('111'));
-//             expect(newState['111']).not.toBeDefined();
-//         });
-//     });
-//
-//     describe('API_UPDATE_INIT action', () => {
-//         it('should add 1 to isUpdating', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new ApiUpdateInitAction({}));
-//             expect(newState.isUpdating).toBe(1);
-//         });
-//     });
-//
-//     describe('API_DELETE_INIT action', () => {
-//         it('should add 1 isDeleting', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new ApiDeleteInitAction({}));
-//             expect(newState.isDeleting).toBe(1);
-//         });
-//     });
-//
-//     describe('API_CREATE_SUCCESS action', () => {
-//         it('should subtract 1 from isCreating', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({}));
-//             expect(state.isCreating - newState.isCreating).toBe(1);
-//         });
-//
-//         it('should add data to the store', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
-//                 jsonApiData: testPayload
-//             }));
-//             expect(newState.data['Article']['1']).toBeDefined();
-//         })
-//     });
-//
-//     describe('API_READ_SUCCESS action', () => {
-//         let query = {
-//             queryId: '111',
-//             type: 'Article',
-//             id: '1'
-//         }
-//         let newState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-//             jsonApiData: testPayload,
-//             query: query
-//         }));
-//         it('should subtract 1 from isReading', () => {
-//             expect(state.isReading - newState.isReading).toBe(1);
-//         });
-//
-//         it('should add data to the store', () => {
-//             expect(newState.data['Article']['1']).toBeDefined();
-//         })
-//
-//         it('should update the query results', () => {
-//             let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-//                 query: {
-//                     id: '1',
-//                     type: 'Article',
-//                     queryId: '111'
-//                 }
-//             }));
-//             let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadSuccessAction({
-//                 jsonApiData: testPayload,
-//                 query: query
-//             }));
-//             expect(newState.queries['111'].resultIds.length).toEqual(11);
-//             expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
-//         });
-//     });
-//
-//     describe('API_UPDATE_SUCCESS action', () => {
-//         let query = {
-//             queryId: '111',
-//             type: 'Article',
-//             id: '1'
-//         }
-//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-//             jsonApiData: testPayload,
-//             query: {
-//                 id: '1',
-//                 type: 'Article',
-//                 queryId: '111'
-//             }
-//         }));
-//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiUpdateSuccessAction({
-//             jsonApiData: {
-//                 data: {
-//                     type: 'Article',
-//                     id: '1',
-//                     attributes: {
-//                         title: 'bla bla bla'
-//                     }
-//                 }
-//             },
-//         }));
-//
-//         it('should subtract 1 from isUpdating', () => {
-//             expect(state.isUpdating - newState.isUpdating).toBe(1);
-//         });
-//
-//         it('should add data to the store', () => {
-//             expect(newState.data['Article']['1'].resource.attributes.title).toEqual('bla bla bla');
-//         })
-//     });
-//
-//     describe('API_DELETE_SUCCESS', () => {
-//
-//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-//             jsonApiData: testPayload,
-//             query: {
-//                 id: '1',
-//                 type: 'Article',
-//                 queryId: '111'
-//             }
-//         }));
-//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiDeleteSuccessAction({
-//             query: {
-//                 type: 'Article'
-//             }
-//         }));
-//
-//         it('should subtract 1 from isDeleting', () => {
-//             expect(state.isDeleting - newState.isDeleting).toBe(1);
-//         });
-//
-//         it('should remove resources from the store', () => {
-//             expect(newState.data['Article']).toEqual({});
-//         });
-//     });
-//
-//     describe('API_CREATE_FAIL', () => {
-//         let tempState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
-//             jsonApiData: testPayload
-//         }));
-//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiCreateFailAction({
-//             jsonApiData: {
-//                 errors: [
-//                     'permission denied'
-//                 ]
-//             },
-//             query: {
-//                 id: '1',
-//                 type: 'Article',
-//             }
-//         }));
-//         it('should add the errors to the resource', () => {
-//             expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
-//         });
-//
-//         it('should subtract 1 from isCreating', () => {
-//             expect(tempState.isCreating - newState.isCreating).toBe(1);
-//         });
-//
-//     });
-//
-//     describe('API_READ_FAIL', () => {
-//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-//             query: {
-//                 id: '1',
-//                 type: 'Article',
-//                 queryId: '111'
-//             }
-//         }));
-//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadFailAction(
-//             {
-//                 jsonApiData: {
-//                     errors: ['permission denied']
-//                 },
-//                 query: {
-//                     queryId: '111',
-//                     id: '1',
-//                     type: 'Article',
-//                 }
-//               }));
-//
-//         it('should add the errors to the resource', () => {
-//             expect(newState.queries['111'].errors[0]).toEqual('permission denied');
-//         });
-//
-//         it('should subtract 1 from isReading', () => {
-//             expect(tempState.isReading - newState.isReading).toBe(1);
-//         });
-//
-//     });
-//
-//     describe('API_UPDATE_FAIL action', () => {
-//         let query = {
-//             queryId: '111',
-//             type: 'Article',
-//             id: '1'
-//         };
-//
-//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-//             jsonApiData: testPayload,
-//             query: query
-//         }));
-//         let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiUpdateInitAction({}));
-//
-//         let newState = NgrxJsonApiStoreReducer(tempState2, new ApiUpdateFailAction({
-//             jsonApiData: {
-//                 errors: ['permission denied']
-//             },
-//             query: {
-//                 queryId: '111',
-//                 id: '1',
-//                 type: 'Article',
-//             }
-//         }));
-//         it('should subtract 1 from isUpdating', () => {
-//             expect(tempState2.isUpdating - newState.isUpdating).toBe(1);
-//         });
-//
-//         it('should add errors to the resource', () => {
-//             expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
-//         });
-//     });
-//
-//     describe('API_DELETE_FAIL action', () => {
-//         let query = {
-//             queryId: '111',
-//             type: 'Article',
-//             id: '1'
-//         };
-//
-//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-//             jsonApiData: testPayload,
-//             query: query
-//         }));
-//         let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiDeleteInitAction({}));
-//
-//         let newState = NgrxJsonApiStoreReducer(tempState2, new ApiDeleteFailAction({
-//             jsonApiData: {
-//                 errors: ['permission denied']
-//             },
-//             query: {
-//                 queryId: '111',
-//                 id: '1',
-//                 type: 'Article',
-//             }
-//         }));
-//         it('should subtract 1 from isDeleting', () => {
-//             expect(tempState2.isDeleting - newState.isDeleting).toBe(1);
-//         });
-//
-//         it('should add errors to the resource', () => {
-//             expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
-//         });
-//
-//     });
-//
-//     describe('QUERY_STORE_SUCCESS action', () => {
-//         let query = {
-//             queryId: '111',
-//             type: 'Article',
-//             id: '1'
-//         }
-//         it('should update the query results', () => {
-//             let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-//                 query: {
-//                     id: '1',
-//                     type: 'Article',
-//                     queryId: '111'
-//                 }
-//             }));
-//             let newState = NgrxJsonApiStoreReducer(tempState, new QueryStoreSuccessAction({
-//                 jsonApiData: testPayload,
-//                 query: query
-//             }));
-//             expect(newState.queries['111'].resultIds.length).toEqual(11);
-//             expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
-//         });
-//     });
-//
-//     describe('PATCH/POST_STORE_RESOURCE action', () => {
-//
-//         it('should patch/post the resource', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
-//                 { type: 'Article', id: '1' }
-//             ));
-//             let newState2 = NgrxJsonApiStoreReducer(state, new PostStoreResourceAction(
-//                 { type: 'Article', id: '1' }
-//             ));
-//             expect(newState.data['Article']['1']).toBeDefined();
-//             expect(newState2.data['Article']['1']).toBeDefined();
-//         });
-//
-//         it('should not update state on second identical post', () => {
-//             let action = new PostStoreResourceAction(
-//                 { type: 'Article', id: '1', attributes: { title: 'sample title' } }
-//             );
-//             let newState = NgrxJsonApiStoreReducer(state, action);
-//             let newState2 = NgrxJsonApiStoreReducer(newState, action);
-//             expect(newState.data['Article']['1']).toBeDefined();
-//             expect(newState2.data['Article']['1']).toBeDefined();
-//             expect(newState).toBe(newState2);
-//             // expect(newState2 === newState).toBeTruthy();
-//         });
-//
-//         it('should not update state on second identical patch', () => {
-//             let action = new PatchStoreResourceAction(
-//                 { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'test description' } }
-//             );
-//             let newState = NgrxJsonApiStoreReducer(state, action);
-//             let newState2 = NgrxJsonApiStoreReducer(newState, action);
-//             expect(newState.data['Article']['1']).toBeDefined();
-//             expect(newState2.data['Article']['1']).toBeDefined();
-//             expect(newState2 === newState).toBeTruthy();
-//         });
-//
-//         it('should not update state on second partial patch', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
-//                 { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'sample description' } }
-//             ));
-//             let newState2 = NgrxJsonApiStoreReducer(newState, new PatchStoreResourceAction(
-//                 { type: 'Article', id: '1', attributes: { title: 'sample title' } }
-//             ));
-//             expect(newState.data['Article']['1'].resource.attributes.title).toEqual("sample title");
-//             expect(newState.data['Article']['1'].resource.attributes.description).toEqual("sample description");
-//             expect(newState2.data['Article']['1'].resource.attributes.title).toEqual("sample title");
-//             expect(newState2.data['Article']['1'].resource.attributes.description).toEqual("sample description");
-//             expect(newState2 === newState).toBeTruthy();
-//         });
-//     });
-//
-//     describe('API_COMMIT_INIT action', () => {
-//         it('should add 1 to isCommitting', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, new ApiCommitInitAction());
-//             expect(newState.isCommitting - state.isCommitting).toBe(1);
-//         });
-//     });
-//
-//     describe('API_COMMIT/SUCCESS_FAIL actions', () => {
-//
-//     });
-//
-//     describe('ALL OTHER ACTIONS', () => {
-//         it('should return the state', () => {
-//             let newState = NgrxJsonApiStoreReducer(state, { type: 'RANDOM_ACTION' });
-//             expect(newState).toEqual(state);
-//         });
-//     });
-//
-// });
+import {
+    NgrxJsonApiStoreReducer,
+    initialNgrxJsonApiState
+} from '../src/reducers';
+import {
+    ApiCommitInitAction,
+    ApiCommitSuccessAction,
+    ApiCommitFailAction,
+    ApiCreateInitAction,
+    ApiCreateSuccessAction,
+    ApiCreateFailAction,
+    ApiUpdateInitAction,
+    ApiUpdateSuccessAction,
+    ApiUpdateFailAction,
+    ApiReadInitAction,
+    ApiReadSuccessAction,
+    ApiReadFailAction,
+    ApiDeleteInitAction,
+    ApiDeleteSuccessAction,
+    ApiDeleteFailAction,
+    ApiRollbackAction,
+    NgrxJsonApiActionTypes,
+    PatchStoreResourceAction,
+    PostStoreResourceAction,
+    RemoveQueryAction,
+    QueryStoreSuccessAction,
+} from '../src/actions';
+import {
+    NgrxJsonApiStore
+} from '../src/interfaces';
+
+import { testPayload } from './test_utils';
+
+describe('NgrxJsonApiReducer', () => {
+
+    let state = initialNgrxJsonApiState;
+    deepFreeze(state);
+
+    describe('API_CREATE_INIT action', () => {
+        it('should add 1 to isCreating', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiCreateInitAction({}));
+            expect(newState.isCreating).toBe(1);
+        });
+    });
+
+    describe('API_READ_INIT action', () => {
+        let newState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+            query: {
+                id: '1',
+                type: 'Article',
+                queryId: '111'
+            }
+        }));
+
+        it('should change isReading status by adding 1', () => {
+            expect(newState.isReading - state.isReading).toBe(1);
+        });
+
+        it('should update the storeQueries', () => {
+            expect(newState.queries['111'].query.type).toEqual('Article');
+            expect(newState.queries['111'].query.id).toEqual('1');
+        });
+    });
+
+    describe('REMOVE_QUERY action', () => {
+        it('should remove query given a queryId', () => {
+            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+                query: {
+                    id: '1',
+                    type: 'Article',
+                    queryId: '111'
+                }
+            }));
+            let newState = NgrxJsonApiStoreReducer(tempState, new RemoveQueryAction('111'));
+            expect(newState['111']).not.toBeDefined();
+        });
+    });
+
+    describe('API_UPDATE_INIT action', () => {
+        it('should add 1 to isUpdating', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiUpdateInitAction({}));
+            expect(newState.isUpdating).toBe(1);
+        });
+    });
+
+    describe('API_DELETE_INIT action', () => {
+        it('should add 1 isDeleting', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiDeleteInitAction({}));
+            expect(newState.isDeleting).toBe(1);
+        });
+    });
+
+    describe('API_CREATE_SUCCESS action', () => {
+        it('should subtract 1 from isCreating', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({}));
+            expect(state.isCreating - newState.isCreating).toBe(1);
+        });
+
+        it('should add data to the store', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
+                jsonApiData: testPayload
+            }));
+            expect(newState.data['Article']['1']).toBeDefined();
+        })
+    });
+
+    describe('API_READ_SUCCESS action', () => {
+        let query = {
+            queryId: '111',
+            type: 'Article',
+            id: '1'
+        }
+        let newState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+            jsonApiData: testPayload,
+            query: query
+        }));
+        it('should subtract 1 from isReading', () => {
+            expect(state.isReading - newState.isReading).toBe(1);
+        });
+
+        it('should add data to the store', () => {
+            expect(newState.data['Article']['1']).toBeDefined();
+        })
+
+        it('should update the query results', () => {
+            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+                query: {
+                    id: '1',
+                    type: 'Article',
+                    queryId: '111'
+                }
+            }));
+            let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadSuccessAction({
+                jsonApiData: testPayload,
+                query: query
+            }));
+            expect(newState.queries['111'].resultIds.length).toEqual(11);
+            expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
+        });
+    });
+
+    describe('API_UPDATE_SUCCESS action', () => {
+        let query = {
+            queryId: '111',
+            type: 'Article',
+            id: '1'
+        }
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+            jsonApiData: testPayload,
+            query: {
+                id: '1',
+                type: 'Article',
+                queryId: '111'
+            }
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiUpdateSuccessAction({
+            jsonApiData: {
+                data: {
+                    type: 'Article',
+                    id: '1',
+                    attributes: {
+                        title: 'bla bla bla'
+                    }
+                }
+            },
+        }));
+
+        it('should subtract 1 from isUpdating', () => {
+            expect(state.isUpdating - newState.isUpdating).toBe(1);
+        });
+
+        it('should add data to the store', () => {
+            expect(newState.data['Article']['1'].resource.attributes.title).toEqual('bla bla bla');
+        })
+    });
+
+    describe('API_DELETE_SUCCESS', () => {
+
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+            jsonApiData: testPayload,
+            query: {
+                id: '1',
+                type: 'Article',
+                queryId: '111'
+            }
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiDeleteSuccessAction({
+            query: {
+                type: 'Article'
+            }
+        }));
+
+        it('should subtract 1 from isDeleting', () => {
+            expect(state.isDeleting - newState.isDeleting).toBe(1);
+        });
+
+        it('should remove resources from the store', () => {
+            expect(newState.data['Article']).toEqual({});
+        });
+    });
+
+    describe('API_CREATE_FAIL', () => {
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
+            jsonApiData: testPayload
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiCreateFailAction({
+            jsonApiData: {
+                errors: [
+                    'permission denied'
+                ]
+            },
+            query: {
+                id: '1',
+                type: 'Article',
+            }
+        }));
+        it('should add the errors to the resource', () => {
+            expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
+        });
+
+        it('should subtract 1 from isCreating', () => {
+            expect(tempState.isCreating - newState.isCreating).toBe(1);
+        });
+
+    });
+
+    describe('API_READ_FAIL', () => {
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+            query: {
+                id: '1',
+                type: 'Article',
+                queryId: '111'
+            }
+        }));
+        let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadFailAction(
+            {
+                jsonApiData: {
+                    errors: ['permission denied']
+                },
+                query: {
+                    queryId: '111',
+                    id: '1',
+                    type: 'Article',
+                }
+              }));
+
+        it('should add the errors to the resource', () => {
+            expect(newState.queries['111'].errors[0]).toEqual('permission denied');
+        });
+
+        it('should subtract 1 from isReading', () => {
+            expect(tempState.isReading - newState.isReading).toBe(1);
+        });
+
+    });
+
+    describe('API_UPDATE_FAIL action', () => {
+        let query = {
+            queryId: '111',
+            type: 'Article',
+            id: '1'
+        };
+
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+            jsonApiData: testPayload,
+            query: query
+        }));
+        let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiUpdateInitAction({}));
+
+        let newState = NgrxJsonApiStoreReducer(tempState2, new ApiUpdateFailAction({
+            jsonApiData: {
+                errors: ['permission denied']
+            },
+            query: {
+                queryId: '111',
+                id: '1',
+                type: 'Article',
+            }
+        }));
+        it('should subtract 1 from isUpdating', () => {
+            expect(tempState2.isUpdating - newState.isUpdating).toBe(1);
+        });
+
+        it('should add errors to the resource', () => {
+            expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
+        });
+    });
+
+    describe('API_DELETE_FAIL action', () => {
+        let query = {
+            queryId: '111',
+            type: 'Article',
+            id: '1'
+        };
+
+        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+            jsonApiData: testPayload,
+            query: query
+        }));
+        let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiDeleteInitAction({}));
+
+        let newState = NgrxJsonApiStoreReducer(tempState2, new ApiDeleteFailAction({
+            jsonApiData: {
+                errors: ['permission denied']
+            },
+            query: {
+                queryId: '111',
+                id: '1',
+                type: 'Article',
+            }
+        }));
+        it('should subtract 1 from isDeleting', () => {
+            expect(tempState2.isDeleting - newState.isDeleting).toBe(1);
+        });
+
+        it('should add errors to the resource', () => {
+            expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
+        });
+
+    });
+
+    describe('QUERY_STORE_SUCCESS action', () => {
+        let query = {
+            queryId: '111',
+            type: 'Article',
+            id: '1'
+        }
+        it('should update the query results', () => {
+            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+                query: {
+                    id: '1',
+                    type: 'Article',
+                    queryId: '111'
+                }
+            }));
+            let newState = NgrxJsonApiStoreReducer(tempState, new QueryStoreSuccessAction({
+                jsonApiData: testPayload,
+                query: query
+            }));
+            expect(newState.queries['111'].resultIds.length).toEqual(11);
+            expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
+        });
+    });
+
+    describe('PATCH/POST_STORE_RESOURCE action', () => {
+
+        it('should patch/post the resource', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
+                { type: 'Article', id: '1' }
+            ));
+            let newState2 = NgrxJsonApiStoreReducer(state, new PostStoreResourceAction(
+                { type: 'Article', id: '1' }
+            ));
+            expect(newState.data['Article']['1']).toBeDefined();
+            expect(newState2.data['Article']['1']).toBeDefined();
+        });
+
+        it('should not update state on second identical post', () => {
+            let action = new PostStoreResourceAction(
+                { type: 'Article', id: '1', attributes: { title: 'sample title' } }
+            );
+            let newState = NgrxJsonApiStoreReducer(state, action);
+            let newState2 = NgrxJsonApiStoreReducer(newState, action);
+            expect(newState.data['Article']['1']).toBeDefined();
+            expect(newState2.data['Article']['1']).toBeDefined();
+            expect(newState).toBe(newState2);
+            // expect(newState2 === newState).toBeTruthy();
+        });
+
+        it('should not update state on second identical patch', () => {
+            let action = new PatchStoreResourceAction(
+                { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'test description' } }
+            );
+            let newState = NgrxJsonApiStoreReducer(state, action);
+            let newState2 = NgrxJsonApiStoreReducer(newState, action);
+            expect(newState.data['Article']['1']).toBeDefined();
+            expect(newState2.data['Article']['1']).toBeDefined();
+            expect(newState2 === newState).toBeTruthy();
+        });
+
+        it('should not update state on second partial patch', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
+                { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'sample description' } }
+            ));
+            let newState2 = NgrxJsonApiStoreReducer(newState, new PatchStoreResourceAction(
+                { type: 'Article', id: '1', attributes: { title: 'sample title' } }
+            ));
+            expect(newState.data['Article']['1'].resource.attributes.title).toEqual("sample title");
+            expect(newState.data['Article']['1'].resource.attributes.description).toEqual("sample description");
+            expect(newState2.data['Article']['1'].resource.attributes.title).toEqual("sample title");
+            expect(newState2.data['Article']['1'].resource.attributes.description).toEqual("sample description");
+            expect(newState2 === newState).toBeTruthy();
+        });
+    });
+
+    describe('API_COMMIT_INIT action', () => {
+        it('should add 1 to isCommitting', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiCommitInitAction());
+            expect(newState.isCommitting - state.isCommitting).toBe(1);
+        });
+    });
+
+    describe('API_COMMIT/SUCCESS_FAIL actions', () => {
+
+    });
+
+    describe('ALL OTHER ACTIONS', () => {
+        it('should return the state', () => {
+            let newState = NgrxJsonApiStoreReducer(state, { type: 'RANDOM_ACTION' });
+            expect(newState).toEqual(state);
+        });
+    });
+
+});

--- a/spec/reducers.spec.ts
+++ b/spec/reducers.spec.ts
@@ -1,424 +1,426 @@
-import {
-    async,
-    inject,
-    fakeAsync,
-    TestBed
-} from '@angular/core/testing';
-
-let deepFreeze = require('deep-freeze');
-
-import _ = require('lodash');
+// import {
+//     async,
+//     inject,
+//     fakeAsync,
+//     TestBed
+// } from '@angular/core/testing';
 //
-import {
-    NgrxJsonApiStoreReducer,
-    initialNgrxJsonApiState
-} from '../src/reducers';
-import {
-    ApiCommitInitAction,
-    ApiCommitSuccessAction,
-    ApiCommitFailAction,
-    ApiCreateInitAction,
-    ApiCreateSuccessAction,
-    ApiCreateFailAction,
-    ApiUpdateInitAction,
-    ApiUpdateSuccessAction,
-    ApiUpdateFailAction,
-    ApiReadInitAction,
-    ApiReadSuccessAction,
-    ApiReadFailAction,
-    ApiDeleteInitAction,
-    ApiDeleteSuccessAction,
-    ApiDeleteFailAction,
-    ApiRollbackAction,
-    NgrxJsonApiActionTypes,
-    PatchStoreResourceAction,
-    PostStoreResourceAction,
-    RemoveQueryAction,
-    QueryStoreSuccessAction,
-} from '../src/actions';
-import {
-    NgrxJsonApiStore
-} from '../src/interfaces';
-
-import { testPayload } from './test_utils';
-
-describe('NgrxJsonApiReducer', () => {
-
-    let state = initialNgrxJsonApiState;
-
-    deepFreeze(state);
-
-    describe('API_CREATE_INIT action', () => {
-        it('should add 1 to isCreating', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiCreateInitAction({}));
-            expect(newState.isCreating).toBe(1);
-        });
-    });
-
-    describe('API_READ_INIT action', () => {
-        let newState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-            query: {
-                id: '1',
-                type: 'Article',
-                queryId: '111'
-            }
-        }));
-
-        it('should change isReading status by adding 1', () => {
-            expect(newState.isReading - state.isReading).toBe(1);
-        });
-
-        it('should update the storeQueries', () => {
-            expect(newState.queries['111'].query.type).toEqual('Article');
-            expect(newState.queries['111'].query.id).toEqual('1');
-        });
-    });
-
-    describe('REMOVE_QUERY action', () => {
-        it('should remove query given a queryId', () => {
-            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-                query: {
-                    id: '1',
-                    type: 'Article',
-                    queryId: '111'
-                }
-            }));
-            let newState = NgrxJsonApiStoreReducer(tempState, new RemoveQueryAction('111'));
-            expect(newState['111']).not.toBeDefined();
-        });
-    });
-
-    describe('API_UPDATE_INIT action', () => {
-        it('should add 1 to isUpdating', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiUpdateInitAction({}));
-            expect(newState.isUpdating).toBe(1);
-        });
-    });
-
-    describe('API_DELETE_INIT action', () => {
-        it('should add 1 isDeleting', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiDeleteInitAction({}));
-            expect(newState.isDeleting).toBe(1);
-        });
-    });
-
-    describe('API_CREATE_SUCCESS action', () => {
-        it('should subtract 1 from isCreating', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({}));
-            expect(state.isCreating - newState.isCreating).toBe(1);
-        });
-
-        it('should add data to the store', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
-                jsonApiData: testPayload
-            }));
-            expect(newState.data['Article']['1']).toBeDefined();
-        })
-    });
-
-    describe('API_READ_SUCCESS action', () => {
-        let query = {
-            queryId: '111',
-            type: 'Article',
-            id: '1'
-        }
-        let newState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-          jsonApiData: testPayload,
-          query: query
-        }));
-        it('should subtract 1 from isReading', () => {
-            expect(state.isReading - newState.isReading).toBe(1);
-        });
-
-        it('should add data to the store', () => {
-            expect(newState.data['Article']['1']).toBeDefined();
-        })
-
-        it('should update the query results', () => {
-            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-                query: {
-                    id: '1',
-                    type: 'Article',
-                    queryId: '111'
-                }
-            }));
-            let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadSuccessAction({
-                jsonApiData: testPayload,
-                query: query
-            }));
-            expect(newState.queries['111'].resultIds.length).toEqual(11);
-            expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
-        });
-    });
-
-    describe('API_UPDATE_SUCCESS action', () => {
-        let query = {
-            queryId: '111',
-            type: 'Article',
-            id: '1'
-        }
-        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-          jsonApiData: testPayload,
-          query: {
-            id: '1',
-            type: 'Article',
-            queryId: '111'
-          }
-        }));
-        let newState = NgrxJsonApiStoreReducer(tempState, new ApiUpdateSuccessAction({
-          jsonApiData: {
-            data: {
-              type: 'Article',
-              id: '1',
-              attributes: {
-                title: 'bla bla bla'
-              }
-            }
-          },
-        }));
-
-        it('should subtract 1 from isUpdating', () => {
-            expect(state.isUpdating - newState.isUpdating).toBe(1);
-        });
-
-        it('should add data to the store', () => {
-            expect(newState.data['Article']['1'].resource.attributes.title).toEqual('bla bla bla');
-        })
-    });
-
-    describe('API_DELETE_SUCCESS', () => {
-
-        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-          jsonApiData: testPayload,
-          query: {
-            id: '1',
-            type: 'Article',
-            queryId: '111'
-          }
-        }));
-        let newState = NgrxJsonApiStoreReducer(tempState, new ApiDeleteSuccessAction({
-          query: {
-            type: 'Article'
-          }
-        }));
-
-        it('should subtract 1 from isDeleting', () => {
-            expect(state.isDeleting - newState.isDeleting).toBe(1);
-        });
-
-        it('should remove resources from the store', () => {
-            expect(newState.data['Article']).toEqual({});
-        });
-    });
-
-    describe('API_CREATE_FAIL', () => {
-        let tempState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
-            jsonApiData: testPayload
-        }));
-        let newState = NgrxJsonApiStoreReducer(tempState, new ApiCreateFailAction({
-            jsonApiData: {
-                errors: [
-                    'permission denied'
-                ]
-            },
-            query: {
-                id: '1',
-                type: 'Article',
-            }
-        }));
-        it('should add the errors to the resource', () => {
-            expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
-        });
-
-        it('should subtract 1 from isCreating', () => {
-            expect(tempState.isCreating - newState.isCreating).toBe(1);
-        });
-
-    });
-
-    describe('API_READ_FAIL', () => {
-        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-            query: {
-                id: '1',
-                type: 'Article',
-                queryId: '111'
-            }
-        }));
-        let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadFailAction({
-            jsonApiData: {
-                errors: ['permission denied']
-            },
-            query: {
-                queryId: '111',
-                id: '1',
-                type: 'Article',
-            }));
-
-        it('should add the errors to the resource', () => {
-            expect(newState.queries['111'].errors[0]).toEqual('permission denied');
-        });
-
-        it('should subtract 1 from isReading', () => {
-            expect(tempState.isReading - newState.isReading).toBe(1);
-        });
-
-    });
-
-    describe('API_UPDATE_FAIL action', () => {
-        let query = {
-            queryId: '111',
-            type: 'Article',
-            id: '1'
-        };
-
-        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-            jsonApiData: testPayload,
-            query: query
-        }));
-        let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiUpdateInitAction({}));
-
-        let newState = NgrxJsonApiStoreReducer(tempState2, new ApiUpdateFailAction({
-            jsonApiData: {
-                errors: ['permission denied']
-            },
-            query: {
-                queryId: '111',
-                id: '1',
-                type: 'Article',
-            }
-        }));
-        it('should subtract 1 from isUpdating', () => {
-            expect(tempState2.isUpdating - newState.isUpdating).toBe(1);
-        });
-
-        it('should add errors to the resource', () => {
-            expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
-        });
-    });
-
-    describe('API_DELETE_FAIL action', () => {
-        let query = {
-            queryId: '111',
-            type: 'Article',
-            id: '1'
-        };
-
-        let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
-            jsonApiData: testPayload,
-            query: query
-        }));
-        let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiDeleteInitAction({}));
-
-        let newState = NgrxJsonApiStoreReducer(tempState2, new ApiDeleteFailAction({
-            jsonApiData: {
-                errors: ['permission denied']
-            },
-            query: {
-                queryId: '111',
-                id: '1',
-                type: 'Article',
-            }
-        }));
-        it('should subtract 1 from isDeleting', () => {
-            expect(tempState2.isDeleting - newState.isDeleting).toBe(1);
-        });
-
-        it('should add errors to the resource', () => {
-            expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
-        });
-
-    });
-
-    describe('QUERY_STORE_SUCCESS action', () => {
-        let query = {
-            queryId: '111',
-            type: 'Article',
-            id: '1'
-        }
-        it('should update the query results', () => {
-            let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
-                query: {
-                    id: '1',
-                    type: 'Article',
-                    queryId: '111'
-                }
-            }));
-            let newState = NgrxJsonApiStoreReducer(tempState, new QueryStoreSuccessAction({
-                jsonApiData: testPayload,
-                query: query
-            }));
-            expect(newState.queries['111'].resultIds.length).toEqual(11);
-            expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
-        });
-    });
-
-    describe('PATCH/POST_STORE_RESOURCE action', () => {
-
-        it('should patch/post the resource', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
-                { type: 'Article', id: '1' }
-            ));
-            let newState2 = NgrxJsonApiStoreReducer(state, new PostStoreResourceAction(
-                { type: 'Article', id: '1' }
-            ));
-            expect(newState.data['Article']['1']).toBeDefined();
-            expect(newState2.data['Article']['1']).toBeDefined();
-        });
-
-        it('should not update state on second identical post', () => {
-            let action = new PostStoreResourceAction(
-                { type: 'Article', id: '1', attributes: { title: 'sample title' } }
-            );
-            let newState = NgrxJsonApiStoreReducer(state, action);
-            let newState2 = NgrxJsonApiStoreReducer(newState, action);
-            expect(newState.data['Article']['1']).toBeDefined();
-            expect(newState2.data['Article']['1']).toBeDefined();
-            expect(newState).toBe(newState2);
-            // expect(newState2 === newState).toBeTruthy();
-        });
-
-        it('should not update state on second identical patch', () => {
-            let action = new PatchStoreResourceAction(
-                { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'test description' } }
-            );
-            let newState = NgrxJsonApiStoreReducer(state, action);
-            let newState2 = NgrxJsonApiStoreReducer(newState, action);
-            expect(newState.data['Article']['1']).toBeDefined();
-            expect(newState2.data['Article']['1']).toBeDefined();
-            expect(newState2 === newState).toBeTruthy();
-        });
-
-        it('should not update state on second partial patch', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
-                { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'sample description' } }
-            ));
-            let newState2 = NgrxJsonApiStoreReducer(newState, new PatchStoreResourceAction(
-                { type: 'Article', id: '1', attributes: { title: 'sample title' } }
-            ));
-            expect(newState.data['Article']['1'].resource.attributes.title).toEqual("sample title");
-            expect(newState.data['Article']['1'].resource.attributes.description).toEqual("sample description");
-            expect(newState2.data['Article']['1'].resource.attributes.title).toEqual("sample title");
-            expect(newState2.data['Article']['1'].resource.attributes.description).toEqual("sample description");
-            expect(newState2 === newState).toBeTruthy();
-        });
-    });
-
-    describe('API_COMMIT_INIT action', () => {
-        it('should add 1 to isCommitting', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiCommitInitAction());
-            expect(newState.isCommitting - state.isCommitting).toBe(1);
-        });
-    });
-
-    describe('API_COMMIT/SUCCESS_FAIL actions', () => {
-
-    });
-
-    describe('ALL OTHER ACTIONS', () => {
-        it('should return the state', () => {
-            let newState = NgrxJsonApiStoreReducer(state, { type: 'RANDOM_ACTION' });
-            expect(newState).toEqual(state);
-        });
-    });
-
-});
+// let deepFreeze = require('deep-freeze');
+//
+// import _ = require('lodash');
+// //
+// import {
+//     NgrxJsonApiStoreReducer,
+//     initialNgrxJsonApiState
+// } from '../src/reducers';
+// import {
+//     ApiCommitInitAction,
+//     ApiCommitSuccessAction,
+//     ApiCommitFailAction,
+//     ApiCreateInitAction,
+//     ApiCreateSuccessAction,
+//     ApiCreateFailAction,
+//     ApiUpdateInitAction,
+//     ApiUpdateSuccessAction,
+//     ApiUpdateFailAction,
+//     ApiReadInitAction,
+//     ApiReadSuccessAction,
+//     ApiReadFailAction,
+//     ApiDeleteInitAction,
+//     ApiDeleteSuccessAction,
+//     ApiDeleteFailAction,
+//     ApiRollbackAction,
+//     NgrxJsonApiActionTypes,
+//     PatchStoreResourceAction,
+//     PostStoreResourceAction,
+//     RemoveQueryAction,
+//     QueryStoreSuccessAction,
+// } from '../src/actions';
+// import {
+//     NgrxJsonApiStore
+// } from '../src/interfaces';
+//
+// import { testPayload } from './test_utils';
+//
+// describe('NgrxJsonApiReducer', () => {
+//
+//     let state = initialNgrxJsonApiState;
+//
+//     deepFreeze(state);
+//
+//     describe('API_CREATE_INIT action', () => {
+//         it('should add 1 to isCreating', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateInitAction({}));
+//             expect(newState.isCreating).toBe(1);
+//         });
+//     });
+//
+//     describe('API_READ_INIT action', () => {
+//         let newState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+//             query: {
+//                 id: '1',
+//                 type: 'Article',
+//                 queryId: '111'
+//             }
+//         }));
+//
+//         it('should change isReading status by adding 1', () => {
+//             expect(newState.isReading - state.isReading).toBe(1);
+//         });
+//
+//         it('should update the storeQueries', () => {
+//             expect(newState.queries['111'].query.type).toEqual('Article');
+//             expect(newState.queries['111'].query.id).toEqual('1');
+//         });
+//     });
+//
+//     describe('REMOVE_QUERY action', () => {
+//         it('should remove query given a queryId', () => {
+//             let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+//                 query: {
+//                     id: '1',
+//                     type: 'Article',
+//                     queryId: '111'
+//                 }
+//             }));
+//             let newState = NgrxJsonApiStoreReducer(tempState, new RemoveQueryAction('111'));
+//             expect(newState['111']).not.toBeDefined();
+//         });
+//     });
+//
+//     describe('API_UPDATE_INIT action', () => {
+//         it('should add 1 to isUpdating', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new ApiUpdateInitAction({}));
+//             expect(newState.isUpdating).toBe(1);
+//         });
+//     });
+//
+//     describe('API_DELETE_INIT action', () => {
+//         it('should add 1 isDeleting', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new ApiDeleteInitAction({}));
+//             expect(newState.isDeleting).toBe(1);
+//         });
+//     });
+//
+//     describe('API_CREATE_SUCCESS action', () => {
+//         it('should subtract 1 from isCreating', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({}));
+//             expect(state.isCreating - newState.isCreating).toBe(1);
+//         });
+//
+//         it('should add data to the store', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
+//                 jsonApiData: testPayload
+//             }));
+//             expect(newState.data['Article']['1']).toBeDefined();
+//         })
+//     });
+//
+//     describe('API_READ_SUCCESS action', () => {
+//         let query = {
+//             queryId: '111',
+//             type: 'Article',
+//             id: '1'
+//         }
+//         let newState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+//             jsonApiData: testPayload,
+//             query: query
+//         }));
+//         it('should subtract 1 from isReading', () => {
+//             expect(state.isReading - newState.isReading).toBe(1);
+//         });
+//
+//         it('should add data to the store', () => {
+//             expect(newState.data['Article']['1']).toBeDefined();
+//         })
+//
+//         it('should update the query results', () => {
+//             let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+//                 query: {
+//                     id: '1',
+//                     type: 'Article',
+//                     queryId: '111'
+//                 }
+//             }));
+//             let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadSuccessAction({
+//                 jsonApiData: testPayload,
+//                 query: query
+//             }));
+//             expect(newState.queries['111'].resultIds.length).toEqual(11);
+//             expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
+//         });
+//     });
+//
+//     describe('API_UPDATE_SUCCESS action', () => {
+//         let query = {
+//             queryId: '111',
+//             type: 'Article',
+//             id: '1'
+//         }
+//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+//             jsonApiData: testPayload,
+//             query: {
+//                 id: '1',
+//                 type: 'Article',
+//                 queryId: '111'
+//             }
+//         }));
+//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiUpdateSuccessAction({
+//             jsonApiData: {
+//                 data: {
+//                     type: 'Article',
+//                     id: '1',
+//                     attributes: {
+//                         title: 'bla bla bla'
+//                     }
+//                 }
+//             },
+//         }));
+//
+//         it('should subtract 1 from isUpdating', () => {
+//             expect(state.isUpdating - newState.isUpdating).toBe(1);
+//         });
+//
+//         it('should add data to the store', () => {
+//             expect(newState.data['Article']['1'].resource.attributes.title).toEqual('bla bla bla');
+//         })
+//     });
+//
+//     describe('API_DELETE_SUCCESS', () => {
+//
+//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+//             jsonApiData: testPayload,
+//             query: {
+//                 id: '1',
+//                 type: 'Article',
+//                 queryId: '111'
+//             }
+//         }));
+//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiDeleteSuccessAction({
+//             query: {
+//                 type: 'Article'
+//             }
+//         }));
+//
+//         it('should subtract 1 from isDeleting', () => {
+//             expect(state.isDeleting - newState.isDeleting).toBe(1);
+//         });
+//
+//         it('should remove resources from the store', () => {
+//             expect(newState.data['Article']).toEqual({});
+//         });
+//     });
+//
+//     describe('API_CREATE_FAIL', () => {
+//         let tempState = NgrxJsonApiStoreReducer(state, new ApiCreateSuccessAction({
+//             jsonApiData: testPayload
+//         }));
+//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiCreateFailAction({
+//             jsonApiData: {
+//                 errors: [
+//                     'permission denied'
+//                 ]
+//             },
+//             query: {
+//                 id: '1',
+//                 type: 'Article',
+//             }
+//         }));
+//         it('should add the errors to the resource', () => {
+//             expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
+//         });
+//
+//         it('should subtract 1 from isCreating', () => {
+//             expect(tempState.isCreating - newState.isCreating).toBe(1);
+//         });
+//
+//     });
+//
+//     describe('API_READ_FAIL', () => {
+//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+//             query: {
+//                 id: '1',
+//                 type: 'Article',
+//                 queryId: '111'
+//             }
+//         }));
+//         let newState = NgrxJsonApiStoreReducer(tempState, new ApiReadFailAction(
+//             {
+//                 jsonApiData: {
+//                     errors: ['permission denied']
+//                 },
+//                 query: {
+//                     queryId: '111',
+//                     id: '1',
+//                     type: 'Article',
+//                 }
+//               }));
+//
+//         it('should add the errors to the resource', () => {
+//             expect(newState.queries['111'].errors[0]).toEqual('permission denied');
+//         });
+//
+//         it('should subtract 1 from isReading', () => {
+//             expect(tempState.isReading - newState.isReading).toBe(1);
+//         });
+//
+//     });
+//
+//     describe('API_UPDATE_FAIL action', () => {
+//         let query = {
+//             queryId: '111',
+//             type: 'Article',
+//             id: '1'
+//         };
+//
+//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+//             jsonApiData: testPayload,
+//             query: query
+//         }));
+//         let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiUpdateInitAction({}));
+//
+//         let newState = NgrxJsonApiStoreReducer(tempState2, new ApiUpdateFailAction({
+//             jsonApiData: {
+//                 errors: ['permission denied']
+//             },
+//             query: {
+//                 queryId: '111',
+//                 id: '1',
+//                 type: 'Article',
+//             }
+//         }));
+//         it('should subtract 1 from isUpdating', () => {
+//             expect(tempState2.isUpdating - newState.isUpdating).toBe(1);
+//         });
+//
+//         it('should add errors to the resource', () => {
+//             expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
+//         });
+//     });
+//
+//     describe('API_DELETE_FAIL action', () => {
+//         let query = {
+//             queryId: '111',
+//             type: 'Article',
+//             id: '1'
+//         };
+//
+//         let tempState = NgrxJsonApiStoreReducer(state, new ApiReadSuccessAction({
+//             jsonApiData: testPayload,
+//             query: query
+//         }));
+//         let tempState2 = NgrxJsonApiStoreReducer(tempState, new ApiDeleteInitAction({}));
+//
+//         let newState = NgrxJsonApiStoreReducer(tempState2, new ApiDeleteFailAction({
+//             jsonApiData: {
+//                 errors: ['permission denied']
+//             },
+//             query: {
+//                 queryId: '111',
+//                 id: '1',
+//                 type: 'Article',
+//             }
+//         }));
+//         it('should subtract 1 from isDeleting', () => {
+//             expect(tempState2.isDeleting - newState.isDeleting).toBe(1);
+//         });
+//
+//         it('should add errors to the resource', () => {
+//             expect(newState.data['Article']['1'].errors[0]).toEqual('permission denied');
+//         });
+//
+//     });
+//
+//     describe('QUERY_STORE_SUCCESS action', () => {
+//         let query = {
+//             queryId: '111',
+//             type: 'Article',
+//             id: '1'
+//         }
+//         it('should update the query results', () => {
+//             let tempState = NgrxJsonApiStoreReducer(state, new ApiReadInitAction({
+//                 query: {
+//                     id: '1',
+//                     type: 'Article',
+//                     queryId: '111'
+//                 }
+//             }));
+//             let newState = NgrxJsonApiStoreReducer(tempState, new QueryStoreSuccessAction({
+//                 jsonApiData: testPayload,
+//                 query: query
+//             }));
+//             expect(newState.queries['111'].resultIds.length).toEqual(11);
+//             expect(newState.queries['111'].resultIds[8]).toEqual({ type: 'Blog', id: '3' });
+//         });
+//     });
+//
+//     describe('PATCH/POST_STORE_RESOURCE action', () => {
+//
+//         it('should patch/post the resource', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
+//                 { type: 'Article', id: '1' }
+//             ));
+//             let newState2 = NgrxJsonApiStoreReducer(state, new PostStoreResourceAction(
+//                 { type: 'Article', id: '1' }
+//             ));
+//             expect(newState.data['Article']['1']).toBeDefined();
+//             expect(newState2.data['Article']['1']).toBeDefined();
+//         });
+//
+//         it('should not update state on second identical post', () => {
+//             let action = new PostStoreResourceAction(
+//                 { type: 'Article', id: '1', attributes: { title: 'sample title' } }
+//             );
+//             let newState = NgrxJsonApiStoreReducer(state, action);
+//             let newState2 = NgrxJsonApiStoreReducer(newState, action);
+//             expect(newState.data['Article']['1']).toBeDefined();
+//             expect(newState2.data['Article']['1']).toBeDefined();
+//             expect(newState).toBe(newState2);
+//             // expect(newState2 === newState).toBeTruthy();
+//         });
+//
+//         it('should not update state on second identical patch', () => {
+//             let action = new PatchStoreResourceAction(
+//                 { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'test description' } }
+//             );
+//             let newState = NgrxJsonApiStoreReducer(state, action);
+//             let newState2 = NgrxJsonApiStoreReducer(newState, action);
+//             expect(newState.data['Article']['1']).toBeDefined();
+//             expect(newState2.data['Article']['1']).toBeDefined();
+//             expect(newState2 === newState).toBeTruthy();
+//         });
+//
+//         it('should not update state on second partial patch', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new PatchStoreResourceAction(
+//                 { type: 'Article', id: '1', attributes: { title: 'sample title', description: 'sample description' } }
+//             ));
+//             let newState2 = NgrxJsonApiStoreReducer(newState, new PatchStoreResourceAction(
+//                 { type: 'Article', id: '1', attributes: { title: 'sample title' } }
+//             ));
+//             expect(newState.data['Article']['1'].resource.attributes.title).toEqual("sample title");
+//             expect(newState.data['Article']['1'].resource.attributes.description).toEqual("sample description");
+//             expect(newState2.data['Article']['1'].resource.attributes.title).toEqual("sample title");
+//             expect(newState2.data['Article']['1'].resource.attributes.description).toEqual("sample description");
+//             expect(newState2 === newState).toBeTruthy();
+//         });
+//     });
+//
+//     describe('API_COMMIT_INIT action', () => {
+//         it('should add 1 to isCommitting', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, new ApiCommitInitAction());
+//             expect(newState.isCommitting - state.isCommitting).toBe(1);
+//         });
+//     });
+//
+//     describe('API_COMMIT/SUCCESS_FAIL actions', () => {
+//
+//     });
+//
+//     describe('ALL OTHER ACTIONS', () => {
+//         it('should return the state', () => {
+//             let newState = NgrxJsonApiStoreReducer(state, { type: 'RANDOM_ACTION' });
+//             expect(newState).toEqual(state);
+//         });
+//     });
+//
+// });

--- a/spec/selectors.spec.ts
+++ b/spec/selectors.spec.ts
@@ -352,15 +352,15 @@ describe('NgrxJsonApiSelectors', () => {
     });
 
     describe('getResults$', () => {
-      it('should get the actual resources that are the results of a query', fakeAsync(() => {
+      it('should get the resourceStore(s) that are the results of a query', fakeAsync(() => {
         let res;
         let sub = obs
         .select('api')
         .let(selectors.getResults$('1'))
         .subscribe(d => res = d);
         tick();
-        expect(res[0].id).toEqual('1');
-        expect(res[1].id).toEqual('2');
+        expect(res[0].resource.id).toEqual('1');
+        expect(res[1].resource.id).toEqual('2');
       }));
     });
 

--- a/spec/selectors.spec.ts
+++ b/spec/selectors.spec.ts
@@ -186,7 +186,7 @@ describe('NgrxJsonApiSelectors', () => {
 
     describe('queryStore$', () => {
 
-        it('should return a single resource store given a getOne query with id and type', fakeAsync(() => {
+        it('should return a single resource given a getOne query with id and type', fakeAsync(() => {
             let res;
             let sub = obs
                 .select('api')
@@ -197,7 +197,7 @@ describe('NgrxJsonApiSelectors', () => {
                 }))
                 .subscribe(d => res = d);
             obs.select('api').let(selectors.getResourceStore$({ type: 'Article', id: '1' }))
-                .subscribe(r => expect(r).toEqual(res));
+                .subscribe(r => expect(r.resource).toEqual(res));
             tick();
         }));
 
@@ -216,8 +216,8 @@ describe('NgrxJsonApiSelectors', () => {
                 }))
                 .subscribe(d => res = d);
             tick();
-            expect(res.resource.id).toEqual('1');
-            expect(res.resource.type).toEqual('Article');
+            expect(res.id).toEqual('1');
+            expect(res.type).toEqual('Article');
         }));
 
         it('should return an empty object for getOne queries that are not found', fakeAsync(() => {
@@ -253,7 +253,7 @@ describe('NgrxJsonApiSelectors', () => {
         //     }).toThrow();
         // }));
 
-        it('should return an array of resourceStore given a getMany query', fakeAsync(() => {
+        it('should return an array of resources given a getMany query', fakeAsync(() => {
             let res;
             let sub = obs
                 .select('api')
@@ -284,8 +284,8 @@ describe('NgrxJsonApiSelectors', () => {
               tick();
               expect(_.isArray(res)).toBeTruthy();
               expect(res.length).toBe(1);
-              expect(res[0].resource.type).toEqual('Article');
-              expect(res[0].resource.id).toEqual('1');
+              expect(res[0].type).toEqual('Article');
+              expect(res[0].id).toEqual('1');
           }));
 
           it('should return an empty array of filtered resourceStore given a getMany query that return nothing', fakeAsync(() => {

--- a/spec/services.spec.ts
+++ b/spec/services.spec.ts
@@ -134,7 +134,7 @@ describe('NgrxJsonApiService', () => {
                 .results
                 .let(service.denormalise());
             resourceStore.subscribe(it => {
-              expect(_.get(it, 'relationships.author.reference')).toBeDefined();
+              expect(_.get(it, 'resource.relationships.author.reference.resource')).toBeDefined();
             });
         });
     });

--- a/spec/services.spec.ts
+++ b/spec/services.spec.ts
@@ -1,7 +1,141 @@
-// import {
-//     async,
-//     inject,
-//     fakeAsync,
-// } from '@angular/core/testing';
-//
-// // to do
+import {
+    async,
+    inject,
+    fakeAsync,
+    tick,
+    TestBed
+} from '@angular/core/testing';
+
+import { Http, HttpModule } from '@angular/http';
+
+import { Store, StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+
+import { NgrxJsonApi } from '../src/api';
+import { NgrxJsonApiService } from '../src/services';
+import { NgrxJsonApiSelectors } from '../src/selectors';
+import { NgrxJsonApiEffects } from '../src/effects';
+
+import {
+    initialNgrxJsonApiState,
+    NgrxJsonApiStoreReducer,
+} from '../src/reducers';
+
+import {
+    NGRX_JSON_API_CONFIG,
+    apiFactory,
+    selectorsFactory,
+    serviceFactory,
+} from '../src/module';
+
+import { updateStoreResources } from '../src/utils';
+
+import {
+    testPayload,
+    resourceDefinitions
+} from './test_utils';
+
+describe('NgrxJsonApiService', () => {
+    let service;
+
+    beforeEach(() => {
+        let store = {
+            api: Object.assign({}, initialNgrxJsonApiState, {
+                data: updateStoreResources({}, testPayload),
+            }, )
+        };
+        TestBed.configureTestingModule({
+            imports: [
+                HttpModule,
+                EffectsModule.run(NgrxJsonApiEffects),
+                // EffectsModule.run(NgrxJsonApiEffects),
+                StoreModule.provideStore({ api: NgrxJsonApiStoreReducer }, store),
+            ],
+            providers: [
+                {
+                    provide: NgrxJsonApi,
+                    useFactory: apiFactory,
+                    deps: [Http, NGRX_JSON_API_CONFIG]
+                },
+                {
+                    provide: NgrxJsonApiService,
+                    useFactory: serviceFactory,
+                    deps: [Store, NgrxJsonApiSelectors]
+                },
+                {
+                    provide: NgrxJsonApiSelectors,
+                    useFactory: selectorsFactory,
+                    deps: [NGRX_JSON_API_CONFIG]
+                },
+                {
+                    provide: NGRX_JSON_API_CONFIG,
+                    useValue: {
+                        storeLocation: 'api',
+                        resourceDefinitions: resourceDefinitions
+                    }
+                },
+            ],
+        })
+    });
+
+    beforeEach(inject([NgrxJsonApiService], (s) => {
+        service = s;
+    }));
+
+    describe('findOne', () => {
+
+    });
+
+    describe('findMany', () => {
+
+    });
+
+    describe('findInternal', () => {
+
+    });
+
+    describe('removeQuery', () => {
+
+    });
+
+    describe('getResourceSnapshot', () => {
+
+    });
+
+    describe('getPersistedResourceSnapshot', () => {
+
+    });
+
+    describe('selectResults', () => {
+
+    });
+
+    describe('selectResultIdentifiers', () => {
+
+    });
+
+    describe('selectResource', () => {
+
+    });
+
+    describe('selectResourceStore', () => {
+
+    });
+
+    describe('denormalise', () => {
+        it('should denormalise a Resource', () => {
+            let query = {
+                id: '1',
+                type: 'Article',
+                queryType: 'getOne',
+                queryId: '22'
+            }
+            let resourceStore = service.findOne(query, false)
+                .results
+                .let(service.denormalise());
+            resourceStore.subscribe(it => {
+              expect(_.get(it, 'relationships.author.reference')).toBeDefined();
+            });
+        });
+    });
+});

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -11,7 +11,7 @@ let deepFreeze = require('deep-freeze');
 import {
     deleteStoreResources,
     denormaliseObject,
-    denormalise,
+    denormaliseResource,
     filterResources,
     //     getSingleResource,
     //     getMultipleResources,
@@ -135,13 +135,13 @@ describe('denormalise and denormaliseObject', () => {
     let storeData = updateStoreResources(initialNgrxJsonApiState.data, testPayload)
     deepFreeze(storeData);
     it('should denormalise a resource with no relatios', () => {
-        let dR1 = denormalise(storeData['Person']['2'], storeData, {}, 'ResourceStore');
+        let dR1 = denormaliseResource(storeData['Person']['2'], storeData, {}, 'ResourceStore');
         expect(dR1.resource).toEqual({
             type: 'Person',
             id: '2',
             name: 'Person 2'
         });
-        let dR2 = denormalise(storeData['Blog']['2'], storeData, {}, 'ResourceStore');
+        let dR2 = denormaliseResource(storeData['Blog']['2'], storeData, {}, 'ResourceStore');
         expect(dR2.resource).toEqual({
             type: 'Blog',
             id: '2',
@@ -149,7 +149,7 @@ describe('denormalise and denormaliseObject', () => {
     });
 
     it('should denormalise a resource with relations', () => {
-        let dR = denormalise(storeData['Blog']['1'], storeData, {}, 'ResourceStore');
+        let dR = denormaliseResource(storeData['Blog']['1'], storeData, {}, 'ResourceStore');
         expect(dR.resource.name).toEqual('Blog 1');
         expect(dR.resource.id).toEqual('1');
         expect(dR.resource.author).toBeDefined();
@@ -157,7 +157,7 @@ describe('denormalise and denormaliseObject', () => {
     });
 
     it('should denormalise a resource with deep relations', () => {
-        let dR = denormalise(storeData['Person']['1'], storeData, {}, 'ResourceStore');
+        let dR = denormaliseResource(storeData['Person']['1'], storeData, {}, 'ResourceStore');
         expect(_.isArray(dR.resource.blogs)).toBeTruthy();
         expect(dR.resource.blogs[0].resource.type).toEqual('Blog');
         expect(dR.resource.blogs[0].resource.id).toEqual('1');
@@ -167,13 +167,13 @@ describe('denormalise and denormaliseObject', () => {
     });
 
     it('should denormalise a resource with very deep relations (circular dependency)', () => {
-        let dR = denormalise(storeData['Article']['1'], storeData, {}, 'ResourceStore');
+        let dR = denormaliseResource(storeData['Article']['1'], storeData, {}, 'ResourceStore');
             expect(dR.resource.author.resource).toEqual(
                 dR.resource.author.resource.blogs[1].resource.author.resource);
     });
 
     it('should return a denormalised resource only when using the default dernomalisation type', () => {
-        let dR = denormalise(storeData['Person']['1'], storeData);
+        let dR = denormaliseResource(storeData['Person']['1'], storeData);
         expect(_.isArray(dR.blogs)).toBeTruthy();
         expect(dR.blogs[0].type).toEqual('Blog');
         expect(dR.blogs[0].id).toEqual('1');
@@ -183,7 +183,7 @@ describe('denormalise and denormaliseObject', () => {
     });
 
     it('should return a denormalise resource only when using the default dernomalisation type', () => {
-        let dR = denormalise(storeData['Blog']['1'], storeData, {}, 'Resource');
+        let dR = denormaliseResource(storeData['Blog']['1'], storeData, {}, 'Resource');
         expect(dR.name).toEqual('Blog 1');
         expect(dR.id).toEqual('1');
         expect(dR.author).toBeDefined();

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -24,9 +24,9 @@ export const NgrxJsonApiActionTypes = {
     API_DELETE_INIT: type('API_DELETE_INIT'),
     API_DELETE_SUCCESS: type('API_DELETE_SUCCESS'),
     API_DELETE_FAIL: type('API_DELETE_FAIL'),
-    API_COMMIT_INIT: type('API_COMMIT_INIT'),
-    API_COMMIT_SUCCESS: type('API_COMMIT_SUCCESS'),
-    API_COMMIT_FAIL: type('API_COMMIT_FAIL'),
+    API_APPLY_INIT: type('API_APPLY_INIT'),
+    API_APPLY_SUCCESS: type('API_APPLY_SUCCESS'),
+    API_APPLY_FAIL: type('API_APPLY_FAIL'),
     API_ROLLBACK: type('API_ROLLBACK'),
     QUERY_STORE_INIT: type('QUERY_STORE_INIT'),
     QUERY_STORE_SUCCESS: type('QUERY_STORE_SUCCESS'),
@@ -36,18 +36,18 @@ export const NgrxJsonApiActionTypes = {
     REMOVE_QUERY: type('REMOVE_QUERY'),
 }
 
-export class ApiCommitInitAction implements Action {
-    type = NgrxJsonApiActionTypes.API_COMMIT_INIT;
-    constructor(public payload : String) { }
+export class ApiApplyInitAction implements Action {
+    type = NgrxJsonApiActionTypes.API_APPLY_INIT;
+    constructor() {}
 }
 
-export class ApiCommitSuccessAction implements Action {
-    type = NgrxJsonApiActionTypes.API_COMMIT_SUCCESS;
+export class ApiApplySuccessAction implements Action {
+    type = NgrxJsonApiActionTypes.API_APPLY_SUCCESS;
     constructor(public payload : Array<Action>) {}
 }
 
-export class ApiCommitFailAction implements Action {
-    type = NgrxJsonApiActionTypes.API_COMMIT_FAIL;
+export class ApiApplyFailAction implements Action {
+    type = NgrxJsonApiActionTypes.API_APPLY_FAIL;
     constructor(public payload : Array<Action>) { }
 }
 
@@ -147,9 +147,9 @@ export class QueryStoreSuccessAction implements Action {
 }
 
 export type NgrxJsonApiActions
-    = ApiCommitInitAction
-    | ApiCommitSuccessAction
-    | ApiCommitFailAction
+    = ApiApplyInitAction
+    | ApiApplySuccessAction
+    | ApiApplyFailAction
     | ApiCreateInitAction
     | ApiCreateSuccessAction
     | ApiCreateFailAction

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,7 +118,7 @@ export class NgrxJsonApi {
                 _generateSortingQueryParams = generateSortingQueryParams;
             }
 
-            if (urlBuilder.generateQueryParams)) {
+            if (urlBuilder.generateQueryParams) {
                 _generateQueryParams = urlBuilder.generateQueryParams;
             } else {
                 _generateQueryParams = generateQueryParams;
@@ -159,6 +159,7 @@ export class NgrxJsonApi {
 
             return this.request(requestOptionsArgs);
         }
+    }
 
     public create(payload: Payload) {
 

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -18,8 +18,8 @@ import 'rxjs/add/operator/toArray';
 
 
 import {
-    ApiCommitFailAction,
-    ApiCommitSuccessAction,
+    ApiApplyFailAction,
+    ApiApplySuccessAction,
     ApiCreateFailAction,
     ApiCreateSuccessAction,
     ApiDeleteFailAction,
@@ -113,11 +113,9 @@ export class NgrxJsonApiEffects implements OnDestroy {
                 .catch(error => Observable.of(new ApiDeleteFailAction(this.toErrorPayload(payload.query, error))));
         });
 
-    @Effect() commitResources$ = this.actions$
-        .ofType(NgrxJsonApiActionTypes.API_COMMIT_INIT)
-        .map<Action, string>(toPayload)
-        .mergeMap((storeLocation: string) => this.store.select(storeLocation).take(1))
-        .mergeMap((store: NgrxJsonApiStore) => {
+    @Effect() applyResources$ = this.actions$
+        .ofType(NgrxJsonApiActionTypes.API_APPLY_INIT)
+        .mergeMap(() => {
             // TODO add support for bulk updates as well (jsonpatch, etc.)
             // to get atomicity for multiple updates
 
@@ -192,21 +190,21 @@ export class NgrxJsonApiEffects implements OnDestroy {
                     }
                 }
 
-                return Observable.of(...actions).concatAll().toArray().map(actions => this.toCommitAction(actions));
+                return Observable.of(...actions).concatAll().toArray().map(actions => this.toApplyAction(actions));
             } else {
-                return Observable.of(new ApiCommitSuccessAction([]));
+                return Observable.of(new ApiApplySuccessAction([]));
             }
         });
 
-    private toCommitAction(actions: Array<Action>) {
+    private toApplyAction(actions: Array<Action>): any {
         for (let action of actions) {
             if (action.type == NgrxJsonApiActionTypes.API_CREATE_FAIL
                 || action.type == NgrxJsonApiActionTypes.API_UPDATE_FAIL
                 || action.type == NgrxJsonApiActionTypes.API_DELETE_FAIL) {
-                return new ApiCommitFailAction(actions);
+                return new ApiApplyFailAction(actions);
             }
         }
-        return new ApiCommitSuccessAction(actions);
+        return new ApiApplySuccessAction(actions);
     }
 
     private toErrorPayload(query: ResourceQuery, response: Response): Payload {

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -7,329 +7,333 @@ import { Effect, Actions, toPayload } from '@ngrx/effects';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/concatAll';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/mapTo';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/switchMapTo';
-import 'rxjs/add/operator/toArray';
-import 'rxjs/add/operator/concatAll';
-import 'rxjs/add/operator/mapTo';
 import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/toArray';
 
 
 import {
-  ApiCommitFailAction,
-  ApiCommitSuccessAction,
-  ApiCreateFailAction,
-  ApiCreateSuccessAction,
-  ApiDeleteFailAction,
-  ApiDeleteSuccessAction,
-  ApiReadFailAction,
-  ApiReadSuccessAction,
-  ApiUpdateFailAction,
-  ApiUpdateSuccessAction,
-  NgrxJsonApiActionTypes,
-  QueryStoreSuccessAction,
+    ApiCommitFailAction,
+    ApiCommitSuccessAction,
+    ApiCreateFailAction,
+    ApiCreateSuccessAction,
+    ApiDeleteFailAction,
+    ApiDeleteSuccessAction,
+    ApiReadFailAction,
+    ApiReadSuccessAction,
+    ApiUpdateFailAction,
+    ApiUpdateSuccessAction,
+    NgrxJsonApiActionTypes,
+    QueryStoreSuccessAction,
 } from './actions';
 import { NgrxJsonApi } from './api';
 import { NgrxJsonApiSelectors } from './selectors';
 import {
-  NgrxJsonApiStore,
-  Payload,
-  ResourceError,
-  ResourceIdentifier,
-  ResourceQuery,
-  ResourceState,
-  ResourceStore,
+    NgrxJsonApiStore,
+    Payload,
+    ResourceError,
+    ResourceIdentifier,
+    ResourceQuery,
+    ResourceState,
+    ResourceStore,
 } from './interfaces';
 
 interface TopologySortContext {
-  pendingResources : Array<ResourceStore>;
-  cursor : number;
-  sorted : Array<ResourceStore>;
-  visited : Array<boolean>;
-  dependencies : { [id: string]: Array<ResourceStore> };
+    pendingResources: Array<ResourceStore>;
+    cursor: number;
+    sorted: Array<ResourceStore>;
+    visited: Array<boolean>;
+    dependencies: { [id: string]: Array<ResourceStore> };
 }
 
 @Injectable()
 export class NgrxJsonApiEffects implements OnDestroy {
-  constructor(
-    private actions$: Actions,
-    private jsonApi: NgrxJsonApi,
-    private store: Store<any>,
-    private selectors: NgrxJsonApiSelectors<any>,
-  ) { }
+    constructor(
+        private actions$: Actions,
+        private jsonApi: NgrxJsonApi,
+        private store: Store<any>,
+        private selectors: NgrxJsonApiSelectors<any>,
+    ) { }
 
-  @Effect() createResource$ = this.actions$
-    .ofType(NgrxJsonApiActionTypes.API_CREATE_INIT)
-    .map<Action, Payload>(toPayload)
-    .mergeMap((payload: Payload) => {
-      return this.jsonApi.create(payload)
-        .mapTo(new ApiCreateSuccessAction(payload))
-        .catch(error => Observable.of(new ApiCreateFailAction(this.toErrorPayload(payload.query, error))));
-    });
+    @Effect() createResource$ = this.actions$
+        .ofType(NgrxJsonApiActionTypes.API_CREATE_INIT)
+        .map<Action, Payload>(toPayload)
+        .mergeMap((payload: Payload) => {
+            return this.jsonApi.create(payload)
+                .mapTo(new ApiCreateSuccessAction(payload))
+                .catch(error => Observable.of(new ApiCreateFailAction(this.toErrorPayload(payload.query, error))));
+        });
 
-  @Effect() updateResource$ = this.actions$
-    .ofType(NgrxJsonApiActionTypes.API_UPDATE_INIT)
-    .map<Action, Payload>(toPayload)
-    .mergeMap((payload: Payload) => {
-      return this.jsonApi.update(payload)
-        .mapTo(new ApiUpdateSuccessAction(payload))
-        .catch(error => Observable.of(new ApiUpdateFailAction(this.toErrorPayload(payload.query, error))));
-    });
+    @Effect() updateResource$ = this.actions$
+        .ofType(NgrxJsonApiActionTypes.API_UPDATE_INIT)
+        .map<Action, Payload>(toPayload)
+        .mergeMap((payload: Payload) => {
+            return this.jsonApi.update(payload)
+                .mapTo(new ApiUpdateSuccessAction(payload))
+                .catch(error => Observable.of(new ApiUpdateFailAction(this.toErrorPayload(payload.query, error))));
+        });
 
-  @Effect() readResource$ = this.actions$
-    .ofType(NgrxJsonApiActionTypes.API_READ_INIT)
-    .map<Action, Payload>(toPayload)
-    .mergeMap((payload: Payload) => {
-      return this.jsonApi.find(payload)
-        .map(res => res.json())
-        .map(data => new ApiReadSuccessAction({
-          jsonApiData: data,
-          query: payload.query
-        }))
-        .catch(error => Observable.of(new ApiReadFailAction(this.toErrorPayload(payload.query, error))));
-    });
+    @Effect() readResource$ = this.actions$
+        .ofType(NgrxJsonApiActionTypes.API_READ_INIT)
+        .map<Action, Payload>(toPayload)
+        .mergeMap((payload: Payload) => {
+            return this.jsonApi.find(payload)
+                .map(res => res.json())
+                .map(data => new ApiReadSuccessAction({
+                    jsonApiData: data,
+                    query: payload.query
+                }))
+                .catch(error => Observable.of(new ApiReadFailAction(this.toErrorPayload(payload.query, error))));
+        });
 
-  @Effect() queryStore$ = this.actions$
-    .ofType(NgrxJsonApiActionTypes.QUERY_STORE_INIT)
-    .map<Action, ResourceQuery>(toPayload)
-    .mergeMap((query: ResourceQuery) => {
-      return this.store.let(this.selectors.getResourceStore$(query))
-      .map(results => Observable.of(new QueryStoreSuccessAction({
-        data: results
-      })));
-    });
+    @Effect() queryStore$ = this.actions$
+        .ofType(NgrxJsonApiActionTypes.QUERY_STORE_INIT)
+        .map<Action, ResourceQuery>(toPayload)
+        .mergeMap((query: ResourceQuery) => {
+            return this.store
+                .select(this.selectors.storeLocation)
+                .let(this.selectors.queryStore$(query))
+                .map(results => new QueryStoreSuccessAction({
+                    jsonApiData: { data: results },
+                    query: query
+                }));
+        });
 
-  @Effect() deleteResource$ = this.actions$
-    .ofType(NgrxJsonApiActionTypes.API_DELETE_INIT)
-    .map<Action, Payload>(toPayload)
-    .mergeMap((payload: Payload) => {
-      return this.jsonApi.delete(payload)
-        .mapTo(new ApiDeleteSuccessAction(payload))
-        .catch(error => Observable.of(new ApiDeleteFailAction(this.toErrorPayload(payload.query, error))));
-    });
+    @Effect() deleteResource$ = this.actions$
+        .ofType(NgrxJsonApiActionTypes.API_DELETE_INIT)
+        .map<Action, Payload>(toPayload)
+        .mergeMap((payload: Payload) => {
+            return this.jsonApi.delete(payload)
+                .mapTo(new ApiDeleteSuccessAction(payload))
+                .catch(error => Observable.of(new ApiDeleteFailAction(this.toErrorPayload(payload.query, error))));
+        });
 
-  @Effect() commitResources$ = this.actions$
-    .ofType(NgrxJsonApiActionTypes.API_COMMIT_INIT)
-    .map<Action, string>(toPayload)
-    .mergeMap((storeLocation : string) => this.store.select(storeLocation).take(1))
-    .mergeMap((store : NgrxJsonApiStore) => {
-      // TODO add support for bulk updates as well (jsonpatch, etc.)
-      // to get atomicity for multiple updates
+    @Effect() commitResources$ = this.actions$
+        .ofType(NgrxJsonApiActionTypes.API_COMMIT_INIT)
+        .map<Action, string>(toPayload)
+        .mergeMap((storeLocation: string) => this.store.select(storeLocation).take(1))
+        .mergeMap((store: NgrxJsonApiStore) => {
+            // TODO add support for bulk updates as well (jsonpatch, etc.)
+            // to get atomicity for multiple updates
 
-      let pending : Array<ResourceStore> = this.getPendingChanges(store);
-      if(pending.length > 0){
-        pending = this.sortPendingChanges(pending);
+            let pending: Array<ResourceStore> = this.getPendingChanges(store);
+            if (pending.length > 0) {
+                pending = this.sortPendingChanges(pending);
 
-        let actions : Array<Observable<Action>> = [];
-        for(let pendingChange of pending){
-          if(pendingChange.state == ResourceState.CREATED){
-            let payload : Payload = {
-              jsonApiData : {
-                data : {
-                  id :  pendingChange.resource.id,
-                  type :  pendingChange.resource.type,
-                  attributes :  pendingChange.resource.attributes,
-                  relationships :  pendingChange.resource.relationships
-                },
-              },
-              query : {
-                queryType : 'create',
-                type : pendingChange.resource.type
-              }
-            };
-            actions.push(this.jsonApi.create(payload)
-              .mapTo(new ApiCreateSuccessAction(payload))
-              .catch(error => Observable.of(new ApiCreateFailAction(this.toErrorPayload(payload.query, error))))
-            );
-          }else if(pendingChange.state == ResourceState.UPDATED){
-            // prepare payload, omit links and meta information
-            let payload : Payload = {
-              jsonApiData : {
-                data : {
-                  id :  pendingChange.resource.id,
-                  type :  pendingChange.resource.type,
-                  attributes :  pendingChange.resource.attributes,
-                  relationships :  pendingChange.resource.relationships
-                },
-              },
-              query : {
-                queryType : 'update',
-                type : pendingChange.resource.type,
-                id : pendingChange.resource.id
-              }
-            };
-            actions.push(this.jsonApi.update(payload)
-              .map(res => res.json())
-              .map(data => new ApiUpdateSuccessAction({
-                jsonApiData: data,
-                query: payload.query
-              }))
-              .catch(error => Observable.of(new ApiUpdateFailAction(this.toErrorPayload(payload.query, error))))
-            );
-          }else if(pendingChange.state == ResourceState.DELETED){
-            let payload : Payload = {
-              query : {
-                queryType : 'deleteOne',
-                type : pendingChange.resource.type,
-                id : pendingChange.resource.id
-              }
-            };
-            actions.push(this.jsonApi.delete(payload)
-              .map(res => res.json())
-              .map(data => new ApiDeleteSuccessAction({
-                jsonApiData: data,
-                query: payload.query
-              }))
-              .catch(error => Observable.of(new ApiDeleteFailAction(this.toErrorPayload(payload.query, error))))
-            );
-          }else{
-            throw new Error("unknown state " + pendingChange.state);
-          }
-        }
+                let actions: Array<Observable<Action>> = [];
+                for (let pendingChange of pending) {
+                    if (pendingChange.state == ResourceState.CREATED) {
+                        let payload: Payload = {
+                            jsonApiData: {
+                                data: {
+                                    id: pendingChange.resource.id,
+                                    type: pendingChange.resource.type,
+                                    attributes: pendingChange.resource.attributes,
+                                    relationships: pendingChange.resource.relationships
+                                },
+                            },
+                            query: {
+                                queryType: 'create',
+                                type: pendingChange.resource.type
+                            }
+                        };
+                        actions.push(this.jsonApi.create(payload)
+                            .mapTo(new ApiCreateSuccessAction(payload))
+                            .catch(error => Observable.of(new ApiCreateFailAction(this.toErrorPayload(payload.query, error))))
+                        );
+                    } else if (pendingChange.state == ResourceState.UPDATED) {
+                        // prepare payload, omit links and meta information
+                        let payload: Payload = {
+                            jsonApiData: {
+                                data: {
+                                    id: pendingChange.resource.id,
+                                    type: pendingChange.resource.type,
+                                    attributes: pendingChange.resource.attributes,
+                                    relationships: pendingChange.resource.relationships
+                                },
+                            },
+                            query: {
+                                queryType: 'update',
+                                type: pendingChange.resource.type,
+                                id: pendingChange.resource.id
+                            }
+                        };
+                        actions.push(this.jsonApi.update(payload)
+                            .map(res => res.json())
+                            .map(data => new ApiUpdateSuccessAction({
+                                jsonApiData: data,
+                                query: payload.query
+                            }))
+                            .catch(error => Observable.of(new ApiUpdateFailAction(this.toErrorPayload(payload.query, error))))
+                        );
+                    } else if (pendingChange.state == ResourceState.DELETED) {
+                        let payload: Payload = {
+                            query: {
+                                queryType: 'deleteOne',
+                                type: pendingChange.resource.type,
+                                id: pendingChange.resource.id
+                            }
+                        };
+                        actions.push(this.jsonApi.delete(payload)
+                            .map(res => res.json())
+                            .map(data => new ApiDeleteSuccessAction({
+                                jsonApiData: data,
+                                query: payload.query
+                            }))
+                            .catch(error => Observable.of(new ApiDeleteFailAction(this.toErrorPayload(payload.query, error))))
+                        );
+                    } else {
+                        throw new Error("unknown state " + pendingChange.state);
+                    }
+                }
 
-        return Observable.of(...actions).concatAll().toArray().map(actions => this.toCommitAction(actions));
-      }else{
-        return Observable.of(new ApiCommitSuccessAction([]));
-      }
-    });
-
-  private toCommitAction(actions : Array<Action>){
-    for(let action of actions){
-      if(action.type == NgrxJsonApiActionTypes.API_CREATE_FAIL
-        || action.type == NgrxJsonApiActionTypes.API_UPDATE_FAIL
-        || action.type == NgrxJsonApiActionTypes.API_DELETE_FAIL){
-        return new ApiCommitFailAction(actions);
-      }
-    }
-    return new ApiCommitSuccessAction(actions);
-  }
-
-  private toErrorPayload(query : ResourceQuery, response : Response) : Payload{
-
-    var contentType = response.headers.get("Content-Type");
-    var document = null;
-    if(contentType == 'application/vnd.api+json'){
-      document = response.json();
-    }
-    if(document && document.errors && document.errors.length > 0){
-      return {
-        query : query,
-        jsonApiData : document
-      }
-    }else{
-      // transform http to json api error
-      let errors : Array<ResourceError> = [];
-      let error : ResourceError = {
-        status : response.status.toString(),
-        code : response.statusText
-      };
-
-      errors.push(error);
-      // got json api errors
-
-      return {
-        query : query,
-        jsonApiData : {
-          errors : errors
-        }
-      };
-    }
-  }
-
-  private toKey(id : ResourceIdentifier){
-    return id.id + "@" + id.type;
-  }
-
-  private sortPendingChanges(pendingResources :  Array<ResourceStore>) : Array<ResourceStore> {
-
-    // allocate dependency
-    let dependencies : any = {};
-    let pendingMap : any = {};
-    for(let pendingResource of pendingResources) {
-      let resource = pendingResource.resource;
-      dependencies[this.toKey(resource)] = [];
-      pendingMap[this.toKey(resource)] = pendingResource;
-    }
-
-    // extract dependencies
-    for(let pendingResource of pendingResources) {
-      let resource = pendingResource.resource;
-      let key = this.toKey(resource);
-      for(let relationshipName in resource.relationships){
-        let data = resource.relationships[relationshipName].data;
-        if (data) {
-          let dependencyIds : Array<ResourceIdentifier> = data instanceof Array ? data : [data];
-          for(let dependencyId of dependencyIds) {
-            let dependencyKey = this.toKey(dependencyId);
-            if (pendingMap[dependencyKey]) {
-              // we have a dependency between two unsaved objects
-              dependencies.push[key].push(pendingMap[dependencyKey]);
+                return Observable.of(...actions).concatAll().toArray().map(actions => this.toCommitAction(actions));
+            } else {
+                return Observable.of(new ApiCommitSuccessAction([]));
             }
-          }
+        });
+
+    private toCommitAction(actions: Array<Action>) {
+        for (let action of actions) {
+            if (action.type == NgrxJsonApiActionTypes.API_CREATE_FAIL
+                || action.type == NgrxJsonApiActionTypes.API_UPDATE_FAIL
+                || action.type == NgrxJsonApiActionTypes.API_DELETE_FAIL) {
+                return new ApiCommitFailAction(actions);
+            }
         }
-      }
+        return new ApiCommitSuccessAction(actions);
     }
 
-    // order
-    let context = {
-      pendingResources : pendingResources,
-      cursor : pendingResources.length,
-      sorted : new Array(pendingResources.length),
-      dependencies : dependencies,
-      visited : []
-    }
+    private toErrorPayload(query: ResourceQuery, response: Response): Payload {
 
-    let i = context.cursor;
-    while (i--) {
-      if (!context.visited[i]) {
-        this.visit(pendingResources[i], i, [], context)
-      }
-    }
-
-    return context.sorted;
-  }
-
-
-  private visit(pendingResource : ResourceStore, i, predecessors, context : TopologySortContext) {
-    let key = this.toKey(pendingResource.resource);
-    if(predecessors.indexOf(key) >= 0) {
-      throw new Error('Cyclic dependency: '+ key + ' with ' + JSON.stringify(predecessors))
-    }
-
-    if (context.visited[i]) {
-      return;
-    }
-    context.visited[i] = true;
-
-    // outgoing edges
-    let outgoing : Array<ResourceStore> = context.dependencies[key];
-
-    var preds = predecessors.concat(key)
-    for(let child of outgoing){
-      this.visit(child, context.pendingResources.indexOf(child), preds, context);
-    };
-
-    context.sorted[--context.cursor] = pendingResource;
-  }
-
-
-  private getPendingChanges(state : NgrxJsonApiStore) : Array<ResourceStore> {
-    let pending : Array<ResourceStore> = [];
-    for(let type in state.data){
-      for(let id in state.data[type]){
-        let storeResource = state.data[type][id];
-        if(storeResource.state != ResourceState.IN_SYNC){
-           pending.push(storeResource);
+        var contentType = response.headers.get("Content-Type");
+        var document = null;
+        if (contentType == 'application/vnd.api+json') {
+            document = response.json();
         }
-      }
+        if (document && document.errors && document.errors.length > 0) {
+            return {
+                query: query,
+                jsonApiData: document
+            }
+        } else {
+            // transform http to json api error
+            let errors: Array<ResourceError> = [];
+            let error: ResourceError = {
+                status: response.status.toString(),
+                code: response.statusText
+            };
+
+            errors.push(error);
+            // got json api errors
+
+            return {
+                query: query,
+                jsonApiData: {
+                    errors: errors
+                }
+            };
+        }
     }
-    return pending;
-  }
+
+    private toKey(id: ResourceIdentifier) {
+        return id.id + "@" + id.type;
+    }
+
+    private sortPendingChanges(pendingResources: Array<ResourceStore>): Array<ResourceStore> {
+
+        // allocate dependency
+        let dependencies: any = {};
+        let pendingMap: any = {};
+        for (let pendingResource of pendingResources) {
+            let resource = pendingResource.resource;
+            dependencies[this.toKey(resource)] = [];
+            pendingMap[this.toKey(resource)] = pendingResource;
+        }
+
+        // extract dependencies
+        for (let pendingResource of pendingResources) {
+            let resource = pendingResource.resource;
+            let key = this.toKey(resource);
+            for (let relationshipName in resource.relationships) {
+                let data = resource.relationships[relationshipName].data;
+                if (data) {
+                    let dependencyIds: Array<ResourceIdentifier> = data instanceof Array ? data : [data];
+                    for (let dependencyId of dependencyIds) {
+                        let dependencyKey = this.toKey(dependencyId);
+                        if (pendingMap[dependencyKey]) {
+                            // we have a dependency between two unsaved objects
+                            dependencies.push[key].push(pendingMap[dependencyKey]);
+                        }
+                    }
+                }
+            }
+        }
+
+        // order
+        let context = {
+            pendingResources: pendingResources,
+            cursor: pendingResources.length,
+            sorted: new Array(pendingResources.length),
+            dependencies: dependencies,
+            visited: []
+        }
+
+        let i = context.cursor;
+        while (i--) {
+            if (!context.visited[i]) {
+                this.visit(pendingResources[i], i, [], context)
+            }
+        }
+
+        return context.sorted;
+    }
 
 
-  ngOnDestroy() {
+    private visit(pendingResource: ResourceStore, i, predecessors, context: TopologySortContext) {
+        let key = this.toKey(pendingResource.resource);
+        if (predecessors.indexOf(key) >= 0) {
+            throw new Error('Cyclic dependency: ' + key + ' with ' + JSON.stringify(predecessors))
+        }
 
-  }
+        if (context.visited[i]) {
+            return;
+        }
+        context.visited[i] = true;
+
+        // outgoing edges
+        let outgoing: Array<ResourceStore> = context.dependencies[key];
+
+        var preds = predecessors.concat(key)
+        for (let child of outgoing) {
+            this.visit(child, context.pendingResources.indexOf(child), preds, context);
+        };
+
+        context.sorted[--context.cursor] = pendingResource;
+    }
+
+
+    private getPendingChanges(state: NgrxJsonApiStore): Array<ResourceStore> {
+        let pending: Array<ResourceStore> = [];
+        for (let type in state.data) {
+            for (let id in state.data[type]) {
+                let storeResource = state.data[type][id];
+                if (storeResource.state != ResourceState.IN_SYNC) {
+                    pending.push(storeResource);
+                }
+            }
+        }
+        return pending;
+    }
+
+
+    ngOnDestroy() {
+
+    }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,9 @@ export * from './api';
 export * from './effects';
 export * from './interfaces';
 export * from './module';
+export * from './pipes';
 export * from './reducers';
 export * from './selectors';
 export * from './services';
-export * from './utils';
 export * from './testing';
-
+export * from './utils';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,7 +33,7 @@ export interface NgrxJsonApiStore {
     isReading: number;
     isUpdating: number;
     isDeleting: number;
-    isCommitting: number;
+    isApplying: number;
 }
 
 export interface NgrxJsonApiConfig {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,11 +1,6 @@
 import { Observable } from "rxjs/Observable";
 import { AnonymousSubscription } from 'rxjs/Subscription';
 
-export type DenormalisationType
-    = 'ResourceStore'
-    | 'Resource'
-    | 'PersistedResource'
-
 export enum Direction {
     ASC,
     DESC

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,11 @@
 import { Observable } from "rxjs/Observable";
 import { AnonymousSubscription } from 'rxjs/Subscription';
 
+export type DenormalisationType
+    = 'ResourceStore'
+    | 'Resource'
+    | 'PersistedResource'
+
 export enum Direction {
     ASC,
     DESC

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,12 +10,13 @@ import { EffectsModule } from '@ngrx/effects';
 import { NgrxJsonApi } from './api';
 import { NgrxJsonApiEffects } from './effects';
 import { NgrxJsonApiSelectors } from './selectors';
+import { NgrxJsonApiService } from './services';
 import {
-  NgrxJsonApiService,
-  SelectResourceStorePipe,
+  DenormaliseResourcePipe,
+  GetResourcePipe,
   SelectResourcePipe,
-  GetResourcePipe
-} from './services';
+  SelectResourceStorePipe,
+} from './pipes';
 
 import { NgrxJsonApiConfig } from './interfaces';
 
@@ -61,7 +62,12 @@ export const configure = (config: NgrxJsonApiConfig): Array<any> => {
 }
 
 @NgModule({
-    declarations : [SelectResourceStorePipe, SelectResourcePipe, GetResourcePipe],
+    declarations : [
+      DenormaliseResourcePipe,
+      GetResourcePipe,
+      SelectResourcePipe,
+      SelectResourceStorePipe,
+    ],
     imports: [
         HttpModule,
         EffectsModule.run(NgrxJsonApiEffects)

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -50,7 +50,7 @@ export class DenormaliseResourcePipe implements PipeTransform {
   }
 
   transform(obs: Observable<Resource> | Observable<ResourceStore>): Observable<any> {
-      return obs.let(this.service.denormalise());
+      return obs.let<Resource | ResourceStore, any>(this.service.denormalise());
   }
 
 }

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -1,0 +1,56 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/let';
+
+import { NgrxJsonApiService } from './services';
+import {
+  Resource,
+  ResourceIdentifier,
+  ResourceStore
+} from './interfaces';
+
+@Pipe({ name: 'jaGetResource' })
+export class GetResourcePipe implements PipeTransform {
+
+    constructor(private service: NgrxJsonApiService) {
+    }
+
+    transform(id: ResourceIdentifier): Resource {
+        return this.service.getResourceSnapshot(id);
+    }
+}
+
+@Pipe({ name: 'jaSelectResource' })
+export class SelectResourcePipe implements PipeTransform {
+
+    constructor(private service: NgrxJsonApiService) {
+    }
+
+    transform(id: ResourceIdentifier): Observable<Resource> {
+        return this.service.selectResource(id);
+    }
+}
+
+@Pipe({ name: 'jaSelectResourceStore' })
+export class SelectResourceStorePipe implements PipeTransform {
+
+    constructor(private service: NgrxJsonApiService) {
+    }
+
+    transform(id: ResourceIdentifier): Observable<ResourceStore> {
+        return this.service.selectResourceStore(id);
+    }
+}
+
+@Pipe({ name: 'denormaliseResource'})
+export class DenormaliseResourcePipe implements PipeTransform {
+
+  constructor(private service: NgrxJsonApiService) {
+  }
+
+  transform(obs: Observable<Resource> | Observable<ResourceStore>): Observable<any> {
+      return obs.let(this.service.denormalise());
+  }
+
+}

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -136,6 +136,15 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
                 );
                 return newState;
             }
+            case NgrxJsonApiActionTypes.QUERY_STORE_INIT: {
+                let query = action.payload as ResourceQuery;
+                if (query.queryId) {
+                    newState = Object.assign({}, state, {
+                        queries: updateQueryParams(state.queries, query),
+                    });
+                }
+                return newState;
+            }
             case NgrxJsonApiActionTypes.QUERY_STORE_SUCCESS: {
                 newState = Object.assign({}, state, {
                     queries: updateQueryResults(

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -26,7 +26,7 @@ export const initialNgrxJsonApiState: NgrxJsonApiStore = {
     isReading: 0,
     isUpdating: 0,
     isDeleting: 0,
-    isCommitting: 0,
+    isApplying: 0,
     data: {},
     queries: {}
 };
@@ -189,19 +189,19 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
                 );
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_COMMIT_INIT: {
-                newState = Object.assign({}, state, { isCommitting: state.isCommitting + 1 });
+            case NgrxJsonApiActionTypes.API_APPLY_INIT: {
+                newState = Object.assign({}, state, { isApplying: state.isApplying + 1 });
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_COMMIT_SUCCESS:
-            case NgrxJsonApiActionTypes.API_COMMIT_FAIL: {
+            case NgrxJsonApiActionTypes.API_APPLY_SUCCESS:
+            case NgrxJsonApiActionTypes.API_APPLY_FAIL: {
                 // apply all the committed or failed changes
                 let actions = action.payload as Array<Action>;
                 newState = state;
                 for (let commitAction of actions) {
                     newState = NgrxJsonApiStoreReducer(newState, commitAction);
                 }
-                newState = Object.assign({}, newState, { isCommitting: state['isCommitting'] - 1 });
+                newState = Object.assign({}, newState, { isApplying: state['isApplying'] - 1 });
                 return newState;
             }
             case NgrxJsonApiActionTypes.API_ROLLBACK: {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -33,7 +33,7 @@ import {
     ResourceStore,
 } from './interfaces';
 import {
-    denormaliseResource,
+    ddenormaliseResourceStore
     transformStoreData,
     transformStoreResources,
     filterResources
@@ -47,20 +47,20 @@ export class NgrxJsonApiSelectors<T> {
     constructor(public config: NgrxJsonApiConfig) {
     }
 
-    private getStoreData$() {
+    public getStoreData$() {
         return (state$: Observable<NgrxJsonApiStore>) => {
             return state$.select('data');
         }
     }
 
-    private getResourceStoreOfType$(type: string) {
+    public getResourceStoreOfType$(type: string) {
         return (state$: Observable<NgrxJsonApiStore>) => {
             return state$.let(this.getStoreData$())
                 .map(resources => resources[type]);
         }
     }
 
-    private queryStore$(query: ResourceQuery) {
+    public queryStore$(query: ResourceQuery) {
         return (state$: Observable<NgrxJsonApiStore>) => {
             let selected$;
             switch (query.queryType) {
@@ -114,13 +114,13 @@ export class NgrxJsonApiSelectors<T> {
         }
     }
 
-    private getStoreQueries$() {
+    public getStoreQueries$() {
         return (state$: Observable<NgrxJsonApiStore>) => {
             return state$.select('queries');
         }
     }
 
-    private getResourceQuery$(queryId: string) {
+    public getResourceQuery$(queryId: string) {
         return (state$: Observable<NgrxJsonApiStore>) => {
             return state$
                 .let(this.getStoreQueries$())

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -162,7 +162,7 @@ export class NgrxJsonApiSelectors<T> {
     public getManyResourceStore$(identifiers: Array<ResourceIdentifier>) {
         return (state$: Observable<NgrxJsonApiStore>) => {
             let obs = identifiers.map(id => state$.let(this.getResourceStore$(id)));
-            return <Array<ResourceStore>>Observable.zip(...obs);
+            return Observable.zip(...obs);
         }
     }
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -147,7 +147,7 @@ export class NgrxJsonApiSelectors<T> {
         return (state$: Observable<NgrxJsonApiStore>) => {
             return state$
                 .let(this.getResultIdentifiers$(queryId))
-                .mergeMap(ids => state$.let(this.getManyResource$(ids)))
+                .mergeMap(ids => state$.let(this.getManyResourceStore$(ids)))
         }
     }
 
@@ -176,8 +176,8 @@ export class NgrxJsonApiSelectors<T> {
 
     public getManyResource$(identifiers: Array<ResourceIdentifier>) {
         return (state$: Observable<NgrxJsonApiStore>) => {
-            let obs = identifiers.map(id => state$.let(this.getResource$(id)));
-            return <Array<Resource>>Observable.zip(...obs)
+            return state$.let(this.getManyResourceStore$(identifiers))
+                .map(it => it.map(r => r.resource));
         }
     }
 

--- a/src/services.ts
+++ b/src/services.ts
@@ -19,6 +19,7 @@ import {
 } from './actions';
 import {
     NgrxJsonApiStore,
+    NgrxJsonApiStoreData,
     Payload,
     QueryType,
     Resource,
@@ -29,7 +30,9 @@ import {
     ResourceRelationship,
     ResourceStore,
 } from './interfaces';
-
+import {
+    denormaliseResource
+} from './utils';
 
 @Injectable()
 export class NgrxJsonApiService {
@@ -150,8 +153,8 @@ export class NgrxJsonApiService {
      */
     public selectResource(identifier: ResourceIdentifier): Observable<Resource> {
         return this.store
-        .select(this.selectors.storeLocation)
-        .let(this.selectors.getResource$(identifier));
+            .select(this.selectors.storeLocation)
+            .let(this.selectors.getResource$(identifier));
     }
 
     /**
@@ -160,8 +163,23 @@ export class NgrxJsonApiService {
      */
     public selectResourceStore(identifier: ResourceIdentifier): Observable<ResourceStore> {
         return this.store
-        .select(this.selectors.storeLocation)
-        .let(this.selectors.getResourceStore$(identifier));
+            .select(this.selectors.storeLocation)
+            .let(this.selectors.getResourceStore$(identifier));
+    }
+
+    public denormalise() {
+        return (resourceStore$: Observable<ResourceStore | Array<ResourceStore>>) {
+            return resourceStore$
+                .combineLatest(this.store
+                    .select(this.selectors.storeLocation)
+                    .let(this.selectors.getStoreData$()),
+                (
+                    resourceStore: ResourceStore,
+                    storeData: NgrxJsonApiStoreData
+                ) => {
+                    return denormaliseResource(resourceStore, storeData)
+                });
+        }
     }
 
     /**

--- a/src/services.ts
+++ b/src/services.ts
@@ -34,7 +34,6 @@ import {
     denormaliseResource
 } from './utils';
 
-@Injectable()
 export class NgrxJsonApiService {
 
     private test: boolean = true;
@@ -48,7 +47,6 @@ export class NgrxJsonApiService {
         private store: Store<any>,
         private selectors: NgrxJsonApiSelectors<any>,
     ) {
-
         this.store.select(selectors.storeLocation).subscribe(it => this.storeSnapshot = it as NgrxJsonApiStore);
     }
 
@@ -168,7 +166,7 @@ export class NgrxJsonApiService {
     }
 
     public denormalise() {
-        return (resourceStore$: Observable<ResourceStore | Array<ResourceStore>>) {
+        return (resourceStore$: Observable<ResourceStore | Array<ResourceStore>>) => {
             return resourceStore$
                 .combineLatest(this.store
                     .select(this.selectors.storeLocation)

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,4 +1,3 @@
-import { Injectable, Pipe, PipeTransform } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';
 
@@ -50,7 +49,11 @@ export class NgrxJsonApiService {
         this.store.select(selectors.storeLocation).subscribe(it => this.storeSnapshot = it as NgrxJsonApiStore);
     }
 
-    public findOne(query: ResourceQuery, fromServer: boolean = true): ResourceQueryHandle<Resource> {
+    public findOne(
+        query: ResourceQuery,
+        fromServer: boolean = true,
+        resource: boolean = false
+    ): ResourceQueryHandle<Resource> {
         query.queryType = "getOne";
         this.findInternal(query, fromServer);
 
@@ -59,7 +62,7 @@ export class NgrxJsonApiService {
                 if (it.length == 0) {
                     return null;
                 } else if (it.length == 1) {
-                    return it[0];
+                    return resource ? it[0].resource : it[0];
                 } else {
                     throw new Error("Unique result expected");
                 }
@@ -69,11 +72,16 @@ export class NgrxJsonApiService {
         }
     }
 
-    public findMany(query: ResourceQuery, fromServer: boolean = true): ResourceQueryHandle<Array<Resource>> {
+    public findMany(
+      query: ResourceQuery,
+      fromServer: boolean = true,
+      resource: boolean = false
+    ): ResourceQueryHandle<Array<Resource>> {
         query.queryType = "getMany";
         this.findInternal(query, fromServer);
         return {
-            results: this.selectResults(query.queryId),
+            results: this.selectResults(query.queryId)
+                .map(it => resource ? it.resource : it),
             unsubscribe: () => this.removeQuery(query.queryId)
         }
     }

--- a/src/services.ts
+++ b/src/services.ts
@@ -218,39 +218,3 @@ export class NgrxJsonApiService {
         this.store.dispatch(new ApiCommitInitAction(storeLocation));
     }
 }
-
-
-
-@Pipe({ name: 'jaGetResource' })
-export class GetResourcePipe implements PipeTransform {
-
-    constructor(private service: NgrxJsonApiService) {
-    }
-
-    transform(id: ResourceIdentifier): Resource {
-        return this.service.getResourceSnapshot(id);
-    }
-}
-
-@Pipe({ name: 'jaSelectResource' })
-export class SelectResourcePipe implements PipeTransform {
-
-    constructor(private service: NgrxJsonApiService) {
-    }
-
-    transform(id: ResourceIdentifier): Observable<Resource> {
-        return this.service.selectResource(id);
-    }
-}
-
-
-@Pipe({ name: 'jaSelectResourceStore' })
-export class SelectResourceStorePipe implements PipeTransform {
-
-    constructor(private service: NgrxJsonApiService) {
-    }
-
-    transform(id: ResourceIdentifier): Observable<ResourceStore> {
-        return this.service.selectResourceStore(id);
-    }
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,13 +56,13 @@ export const denormaliseObject = (
                 } else if (_.isPlainObject(data)) {
                     // hasOne relation
                     let relatedResource = getSingleResourceStore(data, storeData);
-                    denormalisedRelation = denormalise(
+                    denormalisedRelation = denormaliseResource(
                         relatedResource, storeData, bag, denormalisationType);
                 } else if (_.isArray(data)) {
                     // hasMany relation
                     let relatedResources = getMultipleResourceStore(data, storeData);
                     denormalisedRelation = relatedResources.map(
-                        r => denormalise(r, storeData, bag, denormalisationType));
+                        r => denormaliseResource(r, storeData, bag, denormalisationType));
                 }
 
                 denormalised = _.set(
@@ -79,7 +79,7 @@ export const denormaliseObject = (
     return denormalised;
 }
 
-export const denormalise = (
+export const denormaliseResource = (
     resourceStore: ResourceStore,
     storeData: NgrxJsonApiStoreData,
     bag: NgrxJsonApiStoreData = {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,14 +81,14 @@ export const denormaliseResource = (
         return null;
     }
 
-    let newItem = <ResourceStore | Resource>_.cloneDeep(item);
+    let newItem = _.cloneDeep(item);
     let isResourceStore = newItem.hasOwnProperty('resource');
 
-    let resource;
+    let resource : Resource;
     if (isResourceStore) {
-        resource = newItem.resource;
+        resource = <ResourceStore>newItem.resource;
     } else {
-        resource = newItem;
+        resource = <Resource>newItem;
     }
 
     if (_.isUndefined(bag[resource.type])) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ var config = {
     module: {
         rules: [{
             test: /\.js$/,
-            loader: 'babel',
+            loader: 'babel-loader',
             exclude: /(node_modules|bower_components)/
         }, ]
     },

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -20,7 +20,7 @@ var config = {
     module: {
         rules: [{
             test: /\.js$/,
-            loader: 'babel',
+            loader: 'babel-loader',
             exclude: /(node_modules|bower_components)/
         }, ]
     },


### PR DESCRIPTION
This handles #26. I fixed the implementation for denormalisation and added some tests.

There are three types of denormalisations:
1- Resource:
  This will return a Resource object with nested Resource objects
2- PersistedResource:
  This will return a PersistedResource with nested PersistedResource
  objects (not tested!)
3- ResourceStore:
  This will return a ResourceStore with nested ResourseStore objects.
  It looks ugly: `article.resource.author.resource.name` but it may be
  useful for something like `article.resource.author.loading?`.

The default type is "Resource" which returns an object that can be used
like: `article.author.name`, `article.title`, `article.comments[0].text`

Next to come: denormalisation in selectors and/or in the service.