### PR TITLE
Allow service methods to init read/patch/delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "source-map-loader": "^0.1.5",
     "ts-helpers": "1.1.2",
     "tslint": "^4.0.2",
-    "typescript": "2.1.1",
+    "typescript": "2.0.10",
     "webpack": "^2.2.0-rc.0",
     "webpack-bundle-size-analyzer": "^2.0.2",
     "zone.js": "0.7.3"

--- a/spec/actions.spec.ts
+++ b/spec/actions.spec.ts
@@ -19,9 +19,9 @@ import {
     ApiDeleteInitAction,
     ApiDeleteSuccessAction,
     ApiDeleteFailAction,
-    ApiCommitInitAction,
-    ApiCommitSuccessAction,
-    ApiCommitFailAction,
+    ApiApplyInitAction,
+    ApiApplySuccessAction,
+    ApiApplyFailAction,
     ApiRollbackAction,
     QueryStoreInitAction,
     QueryStoreSuccessAction,
@@ -34,6 +34,10 @@ import {
 describe('Json Api Actions', () => {
 
     let actions;
+
+    it('should have a fixed number of actions', () => {
+      expect(Object.keys(NgrxJsonApiActionTypes).length).toEqual(22);
+    });
 
     it('should have an api create init action', () => {
         expect(NgrxJsonApiActionTypes.API_CREATE_INIT).toBeDefined();
@@ -96,18 +100,18 @@ describe('Json Api Actions', () => {
     });
 
     it('should have an api commit init action', () => {
-        expect(NgrxJsonApiActionTypes.API_COMMIT_INIT).toBeDefined();
-        expect(NgrxJsonApiActionTypes.API_COMMIT_INIT).toBe('API_COMMIT_INIT');
+        expect(NgrxJsonApiActionTypes.API_APPLY_INIT).toBeDefined();
+        expect(NgrxJsonApiActionTypes.API_APPLY_INIT).toBe('API_APPLY_INIT');
     });
 
     it('should have an api commit success action', () => {
-        expect(NgrxJsonApiActionTypes.API_COMMIT_SUCCESS).toBeDefined();
-        expect(NgrxJsonApiActionTypes.API_COMMIT_SUCCESS).toBe('API_COMMIT_SUCCESS');
+        expect(NgrxJsonApiActionTypes.API_APPLY_SUCCESS).toBeDefined();
+        expect(NgrxJsonApiActionTypes.API_APPLY_SUCCESS).toBe('API_APPLY_SUCCESS');
     });
 
     it('should have an api commit fail action', () => {
-        expect(NgrxJsonApiActionTypes.API_COMMIT_FAIL).toBeDefined();
-        expect(NgrxJsonApiActionTypes.API_COMMIT_FAIL).toBe('API_COMMIT_FAIL');
+        expect(NgrxJsonApiActionTypes.API_APPLY_FAIL).toBeDefined();
+        expect(NgrxJsonApiActionTypes.API_APPLY_FAIL).toBe('API_APPLY_FAIL');
     });
 
     it('should have a query store init action', () => {
@@ -212,21 +216,21 @@ describe('Json Api Actions', () => {
         expect(action.payload).toEqual({});
     });
 
-    it('should generate an api commit init action using ApiCommitInit', () => {
-      let action = new ApiCommitInitAction({});
-        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_COMMIT_INIT);
+    it('should generate an api commit init action using ApiApplyInit', () => {
+      let action = new ApiApplyInitAction({});
+        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_INIT);
+        expect(action.payload).not.toBeDefined();
+    });
+
+    it('should generate an api commit success action using ApiApplySuccess', () => {
+      let action = new ApiApplySuccessAction({});
+        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_SUCCESS);
         expect(action.payload).toEqual({});
     });
 
-    it('should generate an api commit success action using ApiCommitSuccess', () => {
-      let action = new ApiCommitSuccessAction({});
-        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_COMMIT_SUCCESS);
-        expect(action.payload).toEqual({});
-    });
-
-    it('should generate an api commit fail action using ApiCommitFail', () => {
-      let action = new ApiCommitFailAction({});
-        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_COMMIT_FAIL);
+    it('should generate an api commit fail action using ApiApplyFail', () => {
+      let action = new ApiApplyFailAction({});
+        expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_FAIL);
         expect(action.payload).toEqual({});
     });
 

--- a/spec/reducers.spec.ts
+++ b/spec/reducers.spec.ts
@@ -14,9 +14,9 @@ import {
     initialNgrxJsonApiState
 } from '../src/reducers';
 import {
-    ApiCommitInitAction,
-    ApiCommitSuccessAction,
-    ApiCommitFailAction,
+    ApiApplyInitAction,
+    ApiApplySuccessAction,
+    ApiApplyFailAction,
     ApiCreateInitAction,
     ApiCreateSuccessAction,
     ApiCreateFailAction,
@@ -404,14 +404,14 @@ describe('NgrxJsonApiReducer', () => {
         });
     });
 
-    describe('API_COMMIT_INIT action', () => {
-        it('should add 1 to isCommitting', () => {
-            let newState = NgrxJsonApiStoreReducer(state, new ApiCommitInitAction());
-            expect(newState.isCommitting - state.isCommitting).toBe(1);
+    describe('API_APPLY_INIT action', () => {
+        it('should add 1 to isApplying', () => {
+            let newState = NgrxJsonApiStoreReducer(state, new ApiApplyInitAction());
+            expect(newState.isApplying - state.isApplying).toBe(1);
         });
     });
 
-    describe('API_COMMIT/SUCCESS_FAIL actions', () => {
+    describe('API_APPLY/SUCCESS_FAIL actions', () => {
 
     });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -24,9 +24,9 @@ export const NgrxJsonApiActionTypes = {
     API_DELETE_INIT: type('API_DELETE_INIT'),
     API_DELETE_SUCCESS: type('API_DELETE_SUCCESS'),
     API_DELETE_FAIL: type('API_DELETE_FAIL'),
-    API_COMMIT_INIT: type('API_COMMIT_INIT'),
-    API_COMMIT_SUCCESS: type('API_COMMIT_SUCCESS'),
-    API_COMMIT_FAIL: type('API_COMMIT_FAIL'),
+    API_APPLY_INIT: type('API_APPLY_INIT'),
+    API_APPLY_SUCCESS: type('API_APPLY_SUCCESS'),
+    API_APPLY_FAIL: type('API_APPLY_FAIL'),
     API_ROLLBACK: type('API_ROLLBACK'),
     QUERY_STORE_INIT: type('QUERY_STORE_INIT'),
     QUERY_STORE_SUCCESS: type('QUERY_STORE_SUCCESS'),
@@ -36,18 +36,18 @@ export const NgrxJsonApiActionTypes = {
     REMOVE_QUERY: type('REMOVE_QUERY'),
 }
 
-export class ApiCommitInitAction implements Action {
-    type = NgrxJsonApiActionTypes.API_COMMIT_INIT;
-    constructor(public payload : String) { }
+export class ApiApplyInitAction implements Action {
+    type = NgrxJsonApiActionTypes.API_APPLY_INIT;
+    constructor() {}
 }
 
-export class ApiCommitSuccessAction implements Action {
-    type = NgrxJsonApiActionTypes.API_COMMIT_SUCCESS;
+export class ApiApplySuccessAction implements Action {
+    type = NgrxJsonApiActionTypes.API_APPLY_SUCCESS;
     constructor(public payload : Array<Action>) {}
 }
 
-export class ApiCommitFailAction implements Action {
-    type = NgrxJsonApiActionTypes.API_COMMIT_FAIL;
+export class ApiApplyFailAction implements Action {
+    type = NgrxJsonApiActionTypes.API_APPLY_FAIL;
     constructor(public payload : Array<Action>) { }
 }
 
@@ -147,9 +147,9 @@ export class QueryStoreSuccessAction implements Action {
 }
 
 export type NgrxJsonApiActions
-    = ApiCommitInitAction
-    | ApiCommitSuccessAction
-    | ApiCommitFailAction
+    = ApiApplyInitAction
+    | ApiApplySuccessAction
+    | ApiApplyFailAction
     | ApiCreateInitAction
     | ApiCreateSuccessAction
     | ApiCreateFailAction

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,7 +118,7 @@ export class NgrxJsonApi {
                 _generateSortingQueryParams = generateSortingQueryParams;
             }
 
-            if (urlBuilder.generateQueryParams)) {
+            if (urlBuilder.generateQueryParams) {
                 _generateQueryParams = urlBuilder.generateQueryParams;
             } else {
                 _generateQueryParams = generateQueryParams;
@@ -159,6 +159,7 @@ export class NgrxJsonApi {
 
             return this.request(requestOptionsArgs);
         }
+    }
 
     public create(payload: Payload) {
 

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -198,7 +198,7 @@ export class NgrxJsonApiEffects implements OnDestroy {
             }
         });
 
-    private toCommitAction(actions: Array<Action>) {
+    private toCommitAction(actions: Array<Action>): any {
         for (let action of actions) {
             if (action.type == NgrxJsonApiActionTypes.API_CREATE_FAIL
                 || action.type == NgrxJsonApiActionTypes.API_UPDATE_FAIL

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,7 +33,7 @@ export interface NgrxJsonApiStore {
     isReading: number;
     isUpdating: number;
     isDeleting: number;
-    isCommitting: number;
+    isApplying: number;
 }
 
 export interface NgrxJsonApiConfig {

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,12 +10,13 @@ import { EffectsModule } from '@ngrx/effects';
 import { NgrxJsonApi } from './api';
 import { NgrxJsonApiEffects } from './effects';
 import { NgrxJsonApiSelectors } from './selectors';
+import { NgrxJsonApiService } from './services';
 import {
-  NgrxJsonApiService,
-  SelectResourceStorePipe,
+  DenormaliseResourcePipe,
+  GetResourcePipe,
   SelectResourcePipe,
-  GetResourcePipe
-} from './services';
+  SelectResourceStorePipe,
+} from './pipes';
 
 import { NgrxJsonApiConfig } from './interfaces';
 
@@ -61,7 +62,12 @@ export const configure = (config: NgrxJsonApiConfig): Array<any> => {
 }
 
 @NgModule({
-    declarations : [SelectResourceStorePipe, SelectResourcePipe, GetResourcePipe],
+    declarations : [
+      DenormaliseResourcePipe,
+      GetResourcePipe,
+      SelectResourcePipe,
+      SelectResourceStorePipe,
+    ],
     imports: [
         HttpModule,
         EffectsModule.run(NgrxJsonApiEffects)

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -50,7 +50,7 @@ export class DenormaliseResourcePipe implements PipeTransform {
   }
 
   transform(obs: Observable<Resource> | Observable<ResourceStore>): Observable<any> {
-      return obs.let(this.service.denormalise());
+      return obs.let<Resource | ResourceStore, any>(this.service.denormalise());
   }
 
 }

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -26,7 +26,7 @@ export const initialNgrxJsonApiState: NgrxJsonApiStore = {
     isReading: 0,
     isUpdating: 0,
     isDeleting: 0,
-    isCommitting: 0,
+    isApplying: 0,
     data: {},
     queries: {}
 };
@@ -189,19 +189,19 @@ export const NgrxJsonApiStoreReducer: ActionReducer<any> =
                 );
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_COMMIT_INIT: {
-                newState = Object.assign({}, state, { isCommitting: state.isCommitting + 1 });
+            case NgrxJsonApiActionTypes.API_APPLY_INIT: {
+                newState = Object.assign({}, state, { isApplying: state.isApplying + 1 });
                 return newState;
             }
-            case NgrxJsonApiActionTypes.API_COMMIT_SUCCESS:
-            case NgrxJsonApiActionTypes.API_COMMIT_FAIL: {
+            case NgrxJsonApiActionTypes.API_APPLY_SUCCESS:
+            case NgrxJsonApiActionTypes.API_APPLY_FAIL: {
                 // apply all the committed or failed changes
                 let actions = action.payload as Array<Action>;
                 newState = state;
                 for (let commitAction of actions) {
                     newState = NgrxJsonApiStoreReducer(newState, commitAction);
                 }
-                newState = Object.assign({}, newState, { isCommitting: state['isCommitting'] - 1 });
+                newState = Object.assign({}, newState, { isApplying: state['isApplying'] - 1 });
                 return newState;
             }
             case NgrxJsonApiActionTypes.API_ROLLBACK: {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -162,7 +162,7 @@ export class NgrxJsonApiSelectors<T> {
     public getManyResourceStore$(identifiers: Array<ResourceIdentifier>) {
         return (state$: Observable<NgrxJsonApiStore>) => {
             let obs = identifiers.map(id => state$.let(this.getResourceStore$(id)));
-            return <Array<ResourceStore>>Observable.zip(...obs);
+            return Observable.zip(...obs);
         }
     }
 

--- a/src/services.ts
+++ b/src/services.ts
@@ -81,7 +81,7 @@ export class NgrxJsonApiService {
         this.findInternal(query, fromServer);
         return {
             results: this.selectResults(query.queryId)
-                .map(it => resource ? it.resource : it),
+                .map(it => resource ? it.map(r => r.resource) : it),
             unsubscribe: () => this.removeQuery(query.queryId)
         }
     }
@@ -135,7 +135,7 @@ export class NgrxJsonApiService {
      * @param queryId
      * @returns observable holding the results as array of resources.
      */
-    public selectResults(queryId: string): Observable<Array<Resource>> {
+    public selectResults(queryId: string): Observable<Array<ResourceStore>> {
         return this.store
             .select(this.selectors.storeLocation)
             .let(this.selectors.getResults$(queryId));
@@ -174,7 +174,7 @@ export class NgrxJsonApiService {
     }
 
     public denormalise() {
-        return (resourceStore$: Observable<ResourceStore | Array<ResourceStore>>) => {
+        return (resourceStore$: Observable<ResourceStore | ResourceStore>) => {
             return resourceStore$
                 .combineLatest(this.store
                     .select(this.selectors.storeLocation)

--- a/src/services.ts
+++ b/src/services.ts
@@ -194,8 +194,27 @@ export class NgrxJsonApiService {
      *
      * @param resource
      */
-    public patchResource(resource: Resource) {
+    public patchResource(resource: Resource, toRemote : boolean = false) {
+      if (toRemote) {
+        let payload: Payload = {
+            jsonApiData: {
+                data: {
+                    id: resource.id,
+                    type: resource.type,
+                    attributes: resource.attributes,
+                    relationships: resource.relationships
+                },
+            },
+            query: {
+                queryType: 'update',
+                type: resource.type,
+                id: resource.id
+            }
+        };
+        this.store.dispatch(new ApiUpdateInitAction(payload));
+      } else {
         this.store.dispatch(new PatchStoreResourceAction(resource));
+      }
     }
 
     /**
@@ -205,8 +224,26 @@ export class NgrxJsonApiService {
      *
      * @param resource
      */
-    public postResource(resource: Resource) {
+    public postResource(resource: Resource, toRemote: boolean = false) {
+      if (toRemote) {
+        let payload: Payload = {
+            jsonApiData: {
+                data: {
+                    id: resource.id,
+                    type: resource.type,
+                    attributes: resource.attributes,
+                    relationships: resource.relationships
+                },
+            },
+            query: {
+                queryType: 'create',
+                type: resource.type
+            }
+        };
+        this.store.dispatch(new ApiCreateInitAction(payload));
+      } else {
         this.store.dispatch(new PostStoreResourceAction(resource));
+      }
     }
 
     /**
@@ -214,8 +251,19 @@ export class NgrxJsonApiService {
      *
      * @param resourceId
      */
-    public deleteResource(resourceId: ResourceIdentifier) {
+    public deleteResource(resourceId: ResourceIdentifier, toRemote: boolean = false) {
+      if (toRemote) {
+        let payload: Payload = {
+            query: {
+                queryType: 'deleteOne',
+                type: resourceId.type,
+                id: resourceId.id
+            }
+        };
+        this.store.dispatch(new ApiDeleteInitAction(payload));
+      } else {
         this.store.dispatch(new DeleteStoreResourceAction(resourceId));
+      }
     }
 
     /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ var config = {
     module: {
         rules: [{
             test: /\.js$/,
-            loader: 'babel',
+            loader: 'babel-loader',
             exclude: /(node_modules|bower_components)/
         }, ]
     },

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -20,7 +20,7 @@ var config = {
     module: {
         rules: [{
             test: /\.js$/,
-            loader: 'babel',
+            loader: 'babel-loader',
             exclude: /(node_modules|bower_components)/
         }, ]
     },


### PR DESCRIPTION
Previously, service methods used the "commit" method where they either
add a resource or update it or mark it for deletion. Afterwards a commit
action processes all these. This is useful in many situations. However,
sometimes it is required to perform a patch/post/delete immediately
without using commit.

This PR adds this possibility, for example, to patch a resource and send
the request to the server immediately we use:
```ts
this.service.patch(resource, true)
```

The optional boolean when set to `true` will send `API_DELETE_INIT` or
`API_UPDATE_INIT` or `API_CREATE_INIT` actions.