### PR TITLE
Support error handling for select services 

### DIFF
--- a/spec/selectors.spec.ts
+++ b/spec/selectors.spec.ts
@@ -249,16 +249,6 @@ describe('NgrxJsonApiSelectors', () => {
       expect(res[0].type).toEqual('Article');
     }));
 
-    it('should return undefined if the query was not found', fakeAsync(() => {
-      let res;
-      let sub = obs
-        .select('api')
-        .let(selectors.getResultIdentifiers$('10'))
-        .subscribe(d => res = d);
-      tick();
-      expect(res).not.toBeDefined();
-    }));
-
   });
 
   describe('getResults$', () => {
@@ -271,16 +261,6 @@ describe('NgrxJsonApiSelectors', () => {
       tick();
       expect(res[0].resource.id).toEqual('1');
       expect(res[1].resource.id).toEqual('2');
-    }));
-
-    it('should return undefined if the resultIds of the query are undefined', fakeAsync(() => {
-      let res;
-      let sub = obs
-        .select('api')
-        .let(selectors.getResults$('10'))
-        .subscribe(d => res = d);
-      tick();
-      expect(res).not.toBeDefined();
     }));
 
   });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -108,6 +108,10 @@ export interface QueryParams {
   limit?: number;
 }
 
+export class QueryError extends Error{
+  public errors : Array<ResourceError>
+}
+
 export interface Resource extends ResourceIdentifier {
   attributes?: { [key: string]: any };
   relationships?: { [key: string]: ResourceRelationship };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -108,8 +108,8 @@ export interface QueryParams {
   limit?: number;
 }
 
-export class QueryError extends Error{
-  public errors : Array<ResourceError>
+export class QueryError extends Error {
+  public errors: Array<ResourceError>;
 }
 
 export interface Resource extends ResourceIdentifier {

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -96,17 +96,17 @@ export class NgrxJsonApiSelectors<T> {
   public getResultIdentifiers$(queryId: string) {
     return (state$: Observable<NgrxJsonApiStore>) => {
       return state$
-		  .let(this.getResourceQuery$(queryId))
-		  .filter(it => it.resultIds != null || it.errors != null && it.errors.length > 0)
-		  .map(it => {
-            if(it.errors && it.errors.length > 0){
-              let error = new QueryError();
-              error.errors = it.errors;
-              throw error;
-            }else{
-              return it.resultIds;
-            }
-          });
+        .let(this.getResourceQuery$(queryId))
+        .filter(it => it.resultIds != null || it.errors != null && it.errors.length > 0)
+        .map(it => {
+          if (it.errors && it.errors.length > 0) {
+            let error = new QueryError();
+            error.errors = it.errors;
+            throw error;
+          } else {
+            return it.resultIds;
+          }
+        });
     };
   }
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -31,6 +31,7 @@ import {
   ResourceIdentifier,
   Resource,
   Query,
+  QueryError,
   StoreResource,
 } from './interfaces';
 import {
@@ -95,8 +96,17 @@ export class NgrxJsonApiSelectors<T> {
   public getResultIdentifiers$(queryId: string) {
     return (state$: Observable<NgrxJsonApiStore>) => {
       return state$
-        .let(this.getResourceQuery$(queryId))
-        .map(it => it ? it.resultIds : undefined);
+		  .let(this.getResourceQuery$(queryId))
+		  .filter(it => it.resultIds != null || it.errors != null && it.errors.length > 0)
+		  .map(it => {
+            if(it.errors && it.errors.length > 0){
+              let error = new QueryError();
+              error.errors = it.errors;
+              throw error;
+            }else{
+              return it.resultIds;
+            }
+          });
     };
   }
 


### PR DESCRIPTION
introduced QueryError and checks when reading a query. 

not yet complete, two tests are broken: currently it is allowed to return undefined. I think the getResultIdentifiers$ should not do that and rather wait for either the response or an error. Any select observable accessing a remote server currently returns first a undefined.