### PR TITLE
Path resolver for denormalised resources

### DIFF
--- a/spec/pipes.spec.ts
+++ b/spec/pipes.spec.ts
@@ -18,6 +18,7 @@ import { NgrxJsonApiEffects } from '../src/effects';
 import {
   DenormaliseStoreResourcePipe,
   GetResourcePipe,
+  GetDenormalisedValuePipe,
   SelectResourcePipe,
   SelectStoreResourcePipe,
 } from '../src/pipes';
@@ -91,6 +92,13 @@ describe('Pipes', () => {
 
   describe('GetResourcePipe', () => {
     beforeEach(inject([GetResourcePipe], (p) => {
+      pipe = p;
+    }));
+
+  });
+
+  describe('GetDenormalisedValuePipe', () => {
+    beforeEach(inject([GetDenormalisedValuePipe], (p) => {
       pipe = p;
     }));
 

--- a/spec/pipes.spec.ts
+++ b/spec/pipes.spec.ts
@@ -35,7 +35,10 @@ import {
   serviceFactory,
 } from '../src/module';
 
-import { updateStoreDataFromPayload } from '../src/utils';
+import {
+  denormaliseStoreResource,
+  updateStoreDataFromPayload
+} from '../src/utils';
 
 import {
   testPayload,
@@ -83,6 +86,7 @@ describe('Pipes', () => {
         },
         DenormaliseStoreResourcePipe,
         GetResourcePipe,
+        GetDenormalisedValuePipe,
         SelectResourcePipe,
         SelectStoreResourcePipe,
       ],
@@ -94,7 +98,6 @@ describe('Pipes', () => {
     beforeEach(inject([GetResourcePipe], (p) => {
       pipe = p;
     }));
-
   });
 
   describe('GetDenormalisedValuePipe', () => {
@@ -102,6 +105,33 @@ describe('Pipes', () => {
       pipe = p;
     }));
 
+    let denormalisedR;
+    beforeEach(() => {
+      denormalisedR = denormaliseStoreResource(pipe.service.storeSnapshot.data['Article']['1'], pipe.service.storeSnapshot.data);
+    });
+    it('should get the value from a DenormalisedStoreResource given a simple path: attribute', () => {
+
+      let value = pipe.transform('title', denormalisedR);
+      expect(value).toEqual('Article 1');
+    });
+
+    it('should get the value from a DenormalisedStoreResource given a simple path: related attribute', () => {
+      let value = pipe.transform('author.name', denormalisedR);
+      expect(value).toEqual('Person 1');
+    });
+
+    it('should get a hasOne related resource from a DenormalisedStoreResource given a simple path', () => {
+      let relatedR = pipe.transform('author', denormalisedR);
+      expect(relatedR).toBeDefined();
+      expect(relatedR.resource.type).toEqual('Person');
+    });
+
+    it('should get a hasMany related resource from a DenormalisedStoreResource given a simple path', () => {
+      let relatedR = pipe.transform('comments', denormalisedR);
+      expect(relatedR).toBeDefined();
+      expect(relatedR[0].resource.type).toEqual('Comment');
+      expect(relatedR[0].resource.id).toEqual('1');
+    });
   });
 
   describe('SelectResourcePipe', () => {

--- a/spec/services.spec.ts
+++ b/spec/services.spec.ts
@@ -30,7 +30,10 @@ import {
   serviceFactory,
 } from '../src/module';
 
-import { updateStoreDataFromPayload } from '../src/utils';
+import {
+  denormaliseStoreResource,
+  updateStoreDataFromPayload
+} from '../src/utils';
 
 import {
   testPayload,
@@ -38,7 +41,7 @@ import {
 } from './test_utils';
 
 describe('NgrxJsonApiService', () => {
-  let service;
+  let service: NgrxJsonApiService;
 
   beforeEach(() => {
     let store = {
@@ -237,10 +240,79 @@ describe('NgrxJsonApiService', () => {
   });
 
   describe('getDenormalisedPath', () => {
+    it('should get the denormalised path for a simple', () => {
+      let path = 'title'
+      let resolvedPath = service.getDenormalisedPath(path, 'Article', resourceDefinitions);
+      expect(resolvedPath).toEqual('resource.attributes.title');
+    });
 
+    it('should get the denormalised path for an attribute in a related resource', () => {
+      let path = 'author.firstName'
+      let resolvedPath = service.getDenormalisedPath(path, 'Article', resourceDefinitions);
+      expect(resolvedPath).toEqual(
+        'resource.relationships.author.reference.resource.attributes.firstName'
+      );
+    });
+
+    it('should get the denormalised path for an attribute in a deeply related resource', () => {
+      let path = 'author.profile.id'
+      let resolvedPath = service.getDenormalisedPath(path, 'Article', resourceDefinitions);
+      expect(resolvedPath).toEqual(
+        'resource.relationships.author.reference.resource.relationships.profile.reference.resource.attributes.id'
+      );
+    });
+
+    it('should get the denormalised path for a hasOne related resource', () => {
+      let path = 'author'
+      let resolvedPath = service.getDenormalisedPath(path, 'Article', resourceDefinitions);
+      expect(resolvedPath).toEqual(
+        'resource.relationships.author.reference'
+      );
+    });
+
+    it('should get the denormalised path for a deeply hasOne related resource', () => {
+      let path = 'author.profile'
+      let resolvedPath = service.getDenormalisedPath(path, 'Article', resourceDefinitions);
+      expect(resolvedPath).toEqual(
+        'resource.relationships.author.reference.resource.relationships.profile.reference'
+      );
+    });
+
+    it('should get the denormalised path for a hasMany related resource', () => {
+      let path = 'comments'
+      let resolvedPath = service.getDenormalisedPath(path, 'Article', resourceDefinitions);
+      expect(resolvedPath).toEqual(
+        'resource.relationships.comments.reference'
+      );
+    });
   });
 
   describe('getDenormalisedValue', () => {
+    let denormalisedR;
+    beforeEach(() => {
+      denormalisedR = denormaliseStoreResource(service.storeSnapshot.data['Article']['1'], service.storeSnapshot.data);
+    });
+    it('should get the value from a DenormalisedStoreResource given a simple path: attribute', () => {
+      let value = service.getDenormalisedValue('title', denormalisedR);
+      expect(value).toEqual('Article 1');
+    });
 
+    it('should get the value from a DenormalisedStoreResource given a simple path: related attribute', () => {
+      let value = service.getDenormalisedValue('author.name', denormalisedR);
+      expect(value).toEqual('Person 1');
+    });
+
+    it('should get a hasOne related resource from a DenormalisedStoreResource given a simple path', () => {
+      let relatedR = service.getDenormalisedValue('author', denormalisedR);
+      expect(relatedR).toBeDefined();
+      expect(relatedR.resource.type).toEqual('Person');
+    });
+
+    it('should get a hasMany related resource from a DenormalisedStoreResource given a simple path', () => {
+      let relatedR = service.getDenormalisedValue('comments', denormalisedR);
+      expect(relatedR).toBeDefined();
+      expect(relatedR[0].resource.type).toEqual('Comment');
+      expect(relatedR[0].resource.id).toEqual('1');
+    });
   });
 });

--- a/spec/services.spec.ts
+++ b/spec/services.spec.ts
@@ -234,6 +234,13 @@ describe('NgrxJsonApiService', () => {
         expect(_.get(it[0], 'resource.relationships.author.reference.resource')).toBeDefined();
       });
     });
+  });
+
+  describe('getDenormalisedPath', () => {
+
+  });
+
+  describe('getDenormalisedValue', () => {
 
   });
 });

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -847,6 +847,14 @@ describe('getResourceFieldValueFromPath', () => {
 
 });
 
+describe('getDenormalisedPath', () => {
+  it('should get the denormalised path given a human usable path', () => {
+    let path = 'article.title'
+    let resolvedPath = getDenormalisedPath(path, resourceDefinitions);
+    expect(resolvedPath).toEqual('attributes.title');
+  })
+})
+
 describe('generateIncludedQueryParams', () => {
   it('should generate an included query param given an array of resources to be included', () => {
     let params = generateIncludedQueryParams(['comments', 'comments.author'])

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,6 +14,7 @@ import { NgrxJsonApiService } from './services';
 import {
   DenormaliseStoreResourcePipe,
   GetResourcePipe,
+  GetDenormalisedValuePipe,
   SelectResourcePipe,
   SelectStoreResourcePipe,
 } from './pipes';
@@ -63,6 +64,7 @@ export function configure(config: NgrxJsonApiConfig): Array<any> {
   declarations: [
     DenormaliseStoreResourcePipe,
     GetResourcePipe,
+    GetDenormalisedValuePipe,
     SelectResourcePipe,
     SelectStoreResourcePipe,
   ],

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -44,7 +44,7 @@ export class SelectStoreResourcePipe implements PipeTransform {
 }
 
 
-@Pipe({ name: 'denormalisetoreResource' })
+@Pipe({ name: 'denormaliseStoreResource' })
 export class DenormaliseStoreResourcePipe implements PipeTransform {
 
   constructor(private service: NgrxJsonApiService) {
@@ -53,5 +53,17 @@ export class DenormaliseStoreResourcePipe implements PipeTransform {
   transform(obs: Observable<StoreResource> | Observable<StoreResource[]>
   ): Observable<StoreResource> | Observable<StoreResource[]> {
     return this.service.denormalise(obs);
+  }
+}
+
+
+@Pipe({ name: 'getDenormalisedValue' })
+export class GetDenormalisedValuePipe implements PipeTransform {
+
+  constructor(private service: NgrxJsonApiService) {
+  }
+
+  transform(path: string, storeResource: StoreResource): any {
+    return this.service.getDenormalisedValue(path, storeResource);
   }
 }

--- a/src/services.ts
+++ b/src/services.ts
@@ -196,13 +196,15 @@ export class NgrxJsonApiService {
   }
 
   public getDenormalisedPath(path, resourceType): string {
+    let pathSeparator = _.get(this.selectors.config, 'filteringConfig.pathSeparator') as string;
     return getDenormalisedPath(path, resourceType, this.selectors.config.resourceDefinitions,
-      this.selectors.config.filteringConfig.pathSeparator);
+      pathSeparator);
   }
 
   public getDenormalisedValue(path, storeResource): any {
+    let pathSeparator = _.get(this.selectors.config, 'filteringConfig.pathSeparator') as string;
     return getDenormalisedValue(path, storeResource, this.selectors.config.resourceDefinitions,
-      this.selectors.config.filteringConfig.pathSeparator);
+      pathSeparator);
   }
 
   /**

--- a/src/services.ts
+++ b/src/services.ts
@@ -31,6 +31,8 @@ import {
 } from './interfaces';
 import {
   denormaliseStoreResource,
+  getDenormalisedPath,
+  getDenormalisedValue,
   uuid
 } from './utils';
 
@@ -191,6 +193,16 @@ export class NgrxJsonApiService {
           return denormaliseStoreResource(storeResource, storeData) as StoreResource;
         }
       });
+  }
+
+  public getDenormalisedPath(path, resourceType): string {
+    return getDenormalisedPath(path, resourceType, this.selectors.config.resourceDefinitions,
+      this.selectors.config.filteringConfig.pathSeparator);
+  }
+
+  public getDenormalisedValue(path, storeResource): any {
+    return getDenormalisedValue(path, storeResource, this.selectors.config.resourceDefinitions,
+      this.selectors.config.filteringConfig.pathSeparator);
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,6 +99,10 @@ export const getMultipleStoreResource = (resourceIds: Array<ResourceIdentifier>,
   return resourceIds.map(id => getSingleStoreResource(id, resources));
 };
 
+export const getDenormalisedPath(path: string, resourceDefinitions: Array<ResourceDefinition>) {
+
+}
+
 /**
  * Given two objects, it will merge the second in the first.
  *

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,9 +99,53 @@ export const getMultipleStoreResource = (resourceIds: Array<ResourceIdentifier>,
   return resourceIds.map(id => getSingleStoreResource(id, resources));
 };
 
-export const getDenormalisedPath(path: string, resourceDefinitions: Array<ResourceDefinition>) {
+export const getDenormalisedPath = (path: string, baseResourceType: string,
+  resourceDefinitions: Array<ResourceDefinition>, pathSeparator?: string): string => {
+  let denormPath: string[] = [];
+  if (_.isUndefined(pathSeparator)) {
+    pathSeparator = '.';
+  }
+  let fields: Array<string> = path.split(pathSeparator);
+  let currentResourceType = baseResourceType;
+  for (let i = 0; i < fields.length; i++) {
+    let definition = _.find(resourceDefinitions, { type: currentResourceType });
 
-}
+    if (_.isUndefined(definition)) {
+      throw new Error('Definition not found');
+    }
+    // if both attributes and relationships are missing, raise an error
+    if (_.isUndefined(definition.attributes) && _.isUndefined(definition.relationships)) {
+      throw new Error('Attributes or Relationships must be provided');
+    }
+
+    if (definition.attributes.hasOwnProperty(fields[i])) {
+      denormPath.push('resource', 'attributes', fields[i]);
+      break;
+    } else if (definition.relationships.hasOwnProperty(fields[i])) {
+      let resourceRelation = definition.relationships[fields[i]];
+      if (resourceRelation.relationType === 'hasMany') {
+        if (i !== fields.length - 1) {
+          throw new Error('Cannot filter past a hasMany relation');
+        } else {
+          denormPath.push('resource', 'relationships', fields[i], 'reference');
+        }
+      } else {
+        currentResourceType = resourceRelation.type;
+        denormPath.push('resource', 'relationships', fields[i], 'reference');
+      }
+    } else {
+      throw new Error('Cannot find field in attributes or relationships');
+    }
+  }
+  return denormPath.join(pathSeparator);
+};
+
+export const getDenormalisedValue = (path: string, storeResource: StoreResource,
+  resourceDefinitions: Array<ResourceDefinition>, pathSeparator?: string) => {
+  let denormalisedPath = getDenormalisedPath(path, storeResource.resource.type, resourceDefinitions,
+    pathSeparator);
+  return _.get(storeResource, denormalisedPath);
+};
 
 /**
  * Given two objects, it will merge the second in the first.
@@ -157,21 +201,21 @@ export const updateResourceState = (storeData: NgrxJsonApiStoreData,
   if (_.isUndefined(storeData[resourceId.type])
     || _.isUndefined(storeData[resourceId.type][resourceId.id])) {
 
-      if (resourceState === ResourceState.DELETED) {
-        let newState: NgrxJsonApiStoreData = Object.assign({}, storeData);
-        newState[resourceId.type] = Object.assign({}, newState[resourceId.type]);
-        newState[resourceId.type][resourceId.id] = Object.assign({},
-          newState[resourceId.type][resourceId.id]);
-        newState[resourceId.type][resourceId.id].persistedResource = null;
-        newState[resourceId.type][resourceId.id].resource = {
-          type: resourceId.type,
-          id: resourceId.id
-        };
-        newState[resourceId.type][resourceId.id].state = ResourceState.NOT_LOADED;
-        return newState;
-      } else {
-        return storeData;
-      }
+    if (resourceState === ResourceState.DELETED) {
+      let newState: NgrxJsonApiStoreData = Object.assign({}, storeData);
+      newState[resourceId.type] = Object.assign({}, newState[resourceId.type]);
+      newState[resourceId.type][resourceId.id] = Object.assign({},
+        newState[resourceId.type][resourceId.id]);
+      newState[resourceId.type][resourceId.id].persistedResource = null;
+      newState[resourceId.type][resourceId.id].resource = {
+        type: resourceId.type,
+        id: resourceId.id
+      };
+      newState[resourceId.type][resourceId.id].state = ResourceState.NOT_LOADED;
+      return newState;
+    } else {
+      return storeData;
+    }
   }
   let newState: NgrxJsonApiStoreData = Object.assign({}, storeData);
   newState[resourceId.type] = Object.assign({}, newState[resourceId.type]);


### PR DESCRIPTION
It looks ugly having to write 

`resource.relationships.author.reference.resource.relationships.profile.resource.attributes.name`

This PR will create a method (and a Pipe) that will accept: `author.profile.name` and it will either get that actual field or the long path written above.