### PR TITLE
Return an empty array for queries with no results

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,11 @@ const path = require('path');
 const webpack = require('webpack');
 const ngtools = require('@ngtools/webpack');
 
-const reporters = ['progress', 'jasmine-diff', 'mocha', 'karma-remap-istanbul'];
+const reporters = ['progress', 'jasmine-diff', 'mocha'];
+
+if (process.env['CI']) {
+  reporters.push('karma-remap-istanbul');
+}
 
 module.exports = function(karma) {
   'use strict';

--- a/spec/selectors.spec.ts
+++ b/spec/selectors.spec.ts
@@ -57,9 +57,16 @@ describe('NgrxJsonApiSelectors', () => {
     '2': {
       query: {
         queryId: '2',
-        resultIds: [{ type: 'Blog', id: '1' }]
-      }
+      },
+      resultIds: [{ type: 'Blog', id: '1' }]
+    },
+    '55': {
+      query: {
+        queryId: '55',
+      },
+      resultIds: []
     }
+
   }
   let store = {
     api: Object.assign({}, initialNgrxJsonApiState, {
@@ -262,6 +269,17 @@ describe('NgrxJsonApiSelectors', () => {
       expect(res[0].id).toEqual('1');
       expect(res[1].id).toEqual('2');
     }));
+
+    it('should get return an empty array if there are no results', fakeAsync(() => {
+      let res;
+      let sub = obs
+        .select('api')
+        .let(selectors.getResults$('55'))
+        .subscribe(d => res = d);
+      tick();
+      expect(res).toEqual([]);
+    }));
+
 
   });
 

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -1,6 +1,3 @@
-// import * as _.find from 'lodash/map';
-// import * as _.includes from 'lodash/includes';
-// import * as _.reduce from 'lodash/reduce';
 import * as _ from 'lodash';
 
 
@@ -114,8 +111,8 @@ export class NgrxJsonApiSelectors<T> {
     return (state$: Observable<NgrxJsonApiStore>) => {
       return state$
         .let(this.getResultIdentifiers$(queryId))
-        .mergeMap(ids => ids ? state$.let(
-          this.getManyStoreResource$(ids)) : Observable.of(undefined));
+        .mergeMap(ids => ids.length > 0 ? state$.let(
+          this.getManyStoreResource$(ids)) : Observable.of(new Array<StoreResource>()));
     };
   }
 


### PR DESCRIPTION
When a StoreQuery has an empty `resultsId`, this should be caught
and an empty array should be returned.

Fixes #73 