### PR TITLE
minor misc fixes

### DIFF
--- a/spec/api.spec.ts
+++ b/spec/api.spec.ts
@@ -71,7 +71,7 @@ describe('ngrx json api', () => {
   }));
 
   it('should have the api url', () => {
-    expect(jsonapi.apiUrl).toEqual('myapi.com');
+    expect(jsonapi.config.apiUrl).toEqual('myapi.com');
   });
 
   describe('urlBuilder', () => {

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1002,7 +1002,6 @@ describe('generatePayload', () => {
       type: 'Article'
     }
     let payload = generatePayload(resource, 'POST');
-    expect(payload.query.id).not.toBeDefined();
     expect(payload.query.type).toEqual('Article');
     expect(payload.jsonApiData.data.id).toEqual('10');
     expect(payload.jsonApiData.data.type).toEqual('Article');

--- a/src/api.ts
+++ b/src/api.ts
@@ -37,7 +37,6 @@ export class NgrxJsonApi {
     'Accept': 'application/vnd.api+json'
   });
   public requestUrl: string;
-  public apiUrl = this.config.apiUrl;
   public definitions = this.config.resourceDefinitions;
 
   constructor(
@@ -83,7 +82,7 @@ export class NgrxJsonApi {
 
   private collectionUrlFor(type: string) {
     let collectionPath = this.collectionPathFor(type);
-    return `${this.apiUrl}/${collectionPath}`;
+    return `${this.config.apiUrl}/${collectionPath}`;
   }
 
   private resourcePathFor(type: string, id: string) {
@@ -93,7 +92,7 @@ export class NgrxJsonApi {
 
   private resourceUrlFor(type: string, id: string) {
     let resourcePath = this.resourcePathFor(type, id);
-    return `${this.apiUrl}/${resourcePath}`;
+    return `${this.config.apiUrl}/${resourcePath}`;
   }
 
   public find(query: Query) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -222,7 +222,7 @@ export interface StoreResource extends Resource {
   /**
   * The original resource obtained from the server.
   */
-  persistedResource: Resource;
+  persistedResource?: Resource;
   /**
   * One of the operation types: reading, creating, updating or deleting.
   */
@@ -230,5 +230,5 @@ export interface StoreResource extends Resource {
   /**
   * Errors received from the server after attempting to store the resource.
   */
-  errors: Array<ResourceError>;
+  errors?: Array<ResourceError>;
 }

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -25,7 +25,6 @@ import {
   NgrxJsonApiStore,
   NgrxJsonApiStoreData,
   NgrxJsonApiStoreResources,
-  Resource,
   ResourceIdentifier,
   Query,
   StoreResource,

--- a/src/services.ts
+++ b/src/services.ts
@@ -148,7 +148,7 @@ export class NgrxJsonApiService {
    * @returns observable holding the data as array of resources.
    */
   public selectManyResults(queryId: string,
-      denormalize = false) {
+      denormalize = false): Observable<ManyQueryResult> {
     let queryResult$ = this.store
       .select(this.selectors.storeLocation)
       .let(this.selectors.getManyResults$(queryId));
@@ -165,7 +165,7 @@ export class NgrxJsonApiService {
    * @returns observable holding the data as array of resources.
    */
   public selectOneResults(queryId: string,
-      denormalize = false) {
+      denormalize = false): Observable<OneQueryResult> {
     let queryResult$ = this.store
       .select(this.selectors.storeLocation)
       .let(this.selectors.getOneResult$(queryId));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -767,7 +767,8 @@ export const generatePayload = (resource: Resource, operation: OperationType): P
 
   // 'DELETE' only needs a query and it also needs an id in its query
   // 'PATCH' also needs an id in its query
-  if (operation === 'PATCH' || operation === 'DELETE') {
+  // 'POST' needed locally to allow to write back errors to store if id is available
+  if (operation === 'PATCH' || operation === 'DELETE' || operation === 'POST') {
     payload.query.id = resource.id;
   }
 


### PR DESCRIPTION
- server url always read from configuration and not duplicated to allow reconfiguring or lazy configuring the url.
- some fields on StoreResource made optional to ease setting up new resources by ngrx-json-api consumers and then sending them to the store with the post action.
- removed unused imports
- added explicit return type for some selectors
- allow validation errors for POSTs to be written back to store by remembering the id in the action payload