### PR TITLE
Fix build and remove getOneQueryResult$ selector

### DIFF
--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -162,36 +162,6 @@ export class NgrxJsonApiSelectors<T> {
     };
   }
 
-  public getOneQueryResult$(queryId: string, denormalize: boolean) {
-    return (state$: Observable<NgrxJsonApiStore>) => {
-      let storeQuery = store.queries[queryId];
-      if (!storeQuery) {
-        return Observable.of(undefined);
-      }
-
-      if (_.isEmpty(storeQuery.resultIds)) {
-        let queryResult: OneQueryResult = Object.assign({}, storeQuery, {
-          data: _.isUndefined(storeQuery.resultIds) ? undefined : null
-        });
-        return Observable.of(queryResult);
-      } else {
-        if (storeQuery.resultIds.length >= 2) {
-          throw new Error('expected single result for query ' + storeQuery.query.queryId);
-        }
-        let id = storeQuery.resultIds[0];
-        return state$.let(this.getStoreResource$(id))
-          .map(result => denormalize ? denormaliseStoreResource(result, store.data) : result)
-          .map(result => {
-            let queryResult: OneQueryResult = Object.assign({}, storeQuery, {
-              data: result
-            });
-            return queryResult;
-          });
-      }
-    };
-  }
-
-
   public getPersistedResource$(store: Store<T>, identifier: ResourceIdentifier) {
     return (state$: Observable<NgrxJsonApiStore>) => {
       return state$

--- a/src/services.ts
+++ b/src/services.ts
@@ -25,7 +25,6 @@ import {
 import {
   NgrxJsonApiStore,
   NgrxJsonApiStoreData,
-  Options,
   Resource,
   ResourceIdentifier,
   Query,
@@ -73,8 +72,7 @@ export interface DeleteResourceOptions {
 /**
  * This internface is deprecated, do no longer use.
  */
-export interface Options extends FindOptions, PutQueryOptions,
-    PostResourceOptions, PatchResourceOptions, DeleteResourceOptions {
+export interface Options {
   query?: Query;
   denormalise?: boolean;
   fromServer?: boolean;
@@ -209,7 +207,7 @@ export class NgrxJsonApiService {
     let queryResult$ = this.store
       .select(this.selectors.storeLocation)
       .let(this.selectors.getOneResult$(queryId, denormalize));
-    return queryResult$;
+    return queryResult$ as Observable<OneQueryResult>;
   }
 
   /**
@@ -222,7 +220,7 @@ export class NgrxJsonApiService {
       .let(this.selectors.getStoreResource$(identifier));
   }
 
-  private denormaliseResource
+  public denormaliseResource
   (storeResource$: Observable<StoreResource> | Observable<StoreResource[]>):
     Observable<StoreResource> | Observable<StoreResource[]> {
     return storeResource$


### PR DESCRIPTION
- `getOneQueryResult$` is not used anywhere, it also had an error.
- `Options` cannot extend the specialised Options because the properties need to be set as required or optional in both interfaces.
- Small fix for type assertion.
- `denormaliseResource` needs to be public because it is used in the pipe.