### PR TITLE
Always change the operation status

### DIFF
--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -51,7 +51,12 @@ export function NgrxJsonApiStoreReducer(state: NgrxJsonApiStore = initialNgrxJso
           );
           return newState;
         } else {
-          return state;
+          newState = Object.assign({},
+            state, {
+              isUpdating: state.isUpdating + 1
+            }
+          );
+          return newState;
         }
       }
       case NgrxJsonApiActionTypes.API_READ_INIT: {
@@ -73,7 +78,12 @@ export function NgrxJsonApiStoreReducer(state: NgrxJsonApiStore = initialNgrxJso
           );
           return newState;
         } else {
-          return state;
+          newState = Object.assign({},
+            state, {
+              isUpdating: state.isUpdating + 1
+            }
+          );
+          return newState;
         }
       }
       case NgrxJsonApiActionTypes.API_DELETE_INIT: {


### PR DESCRIPTION
Previously, when trying to create or update a resource which is
already in the store (exactly as it is) the reducers responsible
will ignore the new data and just return the original state.
This has a side effect of ignoring to change `isUpdating` or
`isCreating` which is essential when using the library.

The status update is mandatory regardless if the data is already in
the store or not.