### PR TITLE
interfaces to support code generators #173

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,25 @@ export interface ManyResourceRelationship {
   reference?: Array<StoreResource>;
 }
 
+/**
+ * Used by code generators to navigate relationships in a type-safe manner.
+ * See crnk.io for a first such generator.
+ */
+export interface TypedManyResourceRelationship<T extends StoreResource>
+    extends ManyResourceRelationship {
+  reference?: Array<T>;
+}
+
+/**
+ * Used by code generators to navigate relationships in a type-safe manner.
+ * See crnk.io for a first such generator.
+ */
+export interface TypedOneResourceRelationship<T extends StoreResource>
+    extends OneResourceRelationship {
+  reference?: T;
+}
+
+
 export interface NgrxJsonApiConfig {
   apiUrl: string;
   resourceDefinitions: Array<ResourceDefinition>;


### PR DESCRIPTION
two interfaces have been added to facilitate generating Typescript interfaces from the backend model. The introduced generic interfaces will allow fully typesafe navigation of relationships.

A first backend project supporting this kind of code generation is www.crnk.io.

An example would look like:

````
export module Person{
    export interface Relationships {
        [key: string]: ResourceRelationship;
        address?: TypedOneResourceRelationship<Address>;
    }
    export interface Attributes {
        name?: string;
    }
}
export interface Person extends MetaElement, StoreResource{
    relationships?: Person.Relationships;
    attributes?: Person.Attributes;
}
````