### PR TITLE
add support for server-generated ids #211

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -252,9 +252,11 @@ export interface StoreResource extends Resource {
   errors?: Array<ResourceError>;
 
   /**
-   * new resources may only obtain an id when posted to the server. Till that point a StoreResource can assign
-   * make use of a temporary id and signal this by setting this flag to true. The id will not be transmitted to the
-   * server and the resource is removed from its temporary location (given by its id) as soon as it is posted to the server.
+   * new resources may only obtain an id when posted to the server. Till that point
+   * a StoreResource can assign make use of a temporary id and signal this by setting
+   * this flag to true. The id will not be transmitted to the server and the resource
+   * is removed from its temporary location (given by its id) as soon as it is posted
+   * to the server.
    */
   hasTemporaryId?: boolean;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -250,4 +250,11 @@ export interface StoreResource extends Resource {
   * Errors received from the server after attempting to store the resource.
   */
   errors?: Array<ResourceError>;
+
+  /**
+   * new resources may only obtain an id when posted to the server. Till that point a StoreResource can assign
+   * make use of a temporary id and signal this by setting this flag to true. The id will not be transmitted to the
+   * server and the resource is removed from its temporary location (given by its id) as soon as it is posted to the server.
+   */
+  hasTemporaryId?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -861,7 +861,7 @@ export const generatePayload = (resource: Resource, operation: OperationType): P
     };
   }
 
-  if (operation === 'POST' && resource['hasTemporaryId']){
+  if (operation === 'POST' && resource['hasTemporaryId']) {
     delete payload.jsonApiData.data.id;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -861,6 +861,10 @@ export const generatePayload = (resource: Resource, operation: OperationType): P
     };
   }
 
+  if (operation === 'POST' && resource['hasTemporaryId']){
+    delete payload.jsonApiData.data.id;
+  }
+
   // 'DELETE' only needs a query and it also needs an id in its query
   // 'PATCH' also needs an id in its query
   // 'POST' needed locally to allow to write back errors to store if id is available


### PR DESCRIPTION
introduced hasTemporaryId flag to mark a resource as having a temporary ID till the point a permanent one is assigned by a POST request.