### PR TITLE
Remove explicit json parsing

### DIFF
--- a/src/effects.ts
+++ b/src/effects.ts
@@ -328,7 +328,7 @@ export class NgrxJsonApiEffects implements OnDestroy {
       // transform http to json api error
       let errors: Array<ResourceError> = [];
       let error: ResourceError = {
-        status: response.status.toString(),
+        status: String(response.status),
         code: response.statusText,
       };
 

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -95,7 +95,6 @@ export class NgrxJsonApiEffects implements OnDestroy {
     .mergeMap((query: Query) => {
       return this.jsonApi
         .find(query)
-        .map(res => res.json())
         .map(
           data =>
             new ApiGetSuccessAction({
@@ -138,7 +137,6 @@ export class NgrxJsonApiEffects implements OnDestroy {
     .mergeMap((payload: Payload) => {
       return this.jsonApi
         .delete(payload.query)
-        .map(res => res.json())
         .map(
           data =>
             new ApiDeleteSuccessAction({
@@ -238,7 +236,6 @@ export class NgrxJsonApiEffects implements OnDestroy {
             actions.push(
               this.jsonApi
                 .update(payload.query, payload.jsonApiData)
-                .map(res => res.json())
                 .map(
                   data =>
                     new ApiPatchSuccessAction({
@@ -262,7 +259,6 @@ export class NgrxJsonApiEffects implements OnDestroy {
             actions.push(
               this.jsonApi
                 .delete(payload.query)
-                .map(res => res.json())
                 .map(
                   data =>
                     new ApiDeleteSuccessAction({


### PR DESCRIPTION
This update removes calls to explicitly parse responses as json, i.e. `.map(res => res.json())`, because we’re now using the new `HttpClient` and it’s not necessary. This was causing issues such as #217.

Unfortunately the build is failing for me, so not quite sure how to proceed. @abdulhaq-e any thoughts?