### PR TITLE
Fix typescript assignable datatype ambiguities

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,7 +54,7 @@ export const denormaliseObject = (
       } else if (_.isArray(data)) {
         // hasMany relation
         let relatedRSs: Array<StoreResource> = getMultipleStoreResource(
-          data,
+          <ResourceIdentifier[]>data,
           storeData
         );
         relationDenorm = relatedRSs.map(r =>
@@ -587,7 +587,7 @@ export const updateStoreDataFromPayload = (
     return storeData;
   }
 
-  data = _.isArray(data) ? data : [data];
+  data = _.isArray(data) ? <Resource[]>data : <Resource[]>[data];
 
   let included = <Array<Resource>>_.get(payload, 'included');
 


### PR DESCRIPTION
Prior to these changes, I was experiencing the following errors:

```shell
[22:57:30]  typescript: node_modules/ngrx-json-api/src/utils.ts, line: 57
            Argument of type 'ResourceIdentifier | ResourceIdentifier[]' is not assignable to parameter of type
            'ResourceIdentifier[]'. Type 'ResourceIdentifier' is not assignable to type 'ResourceIdentifier[]'. Property
            'length' is missing in type 'ResourceIdentifier'.

      L56:  let relatedRSs: Array<StoreResource> = getMultipleStoreResource(
      L57:    data,
      L58:    storeData

[22:57:30]  typescript: node_modules/ngrx-json-api/src/utils.ts, line: 590
            Type 'Resource | (Resource | Resource[])[]' is not assignable to type 'Resource | Resource[]'. Type
            '(Resource | Resource[])[]' is not assignable to type 'Resource | Resource[]'. Type '(Resource |
            Resource[])[]' is not assignable to type 'Resource[]'. Type 'Resource | Resource[]' is not assignable to
            type 'Resource'. Type 'Resource[]' is not assignable to type 'Resource'. Property 'type' is missing in type
            'Resource[]'.

     L590:    data = _.isArray(data) ? data : [data];

[22:57:30]  typescript: node_modules/ngrx-json-api/src/utils.ts, line: 595
            Type 'Resource' is not an array type.

     L594:  if (!_.isUndefined(included)) {
     L595:    data = [...data, ...included];
```

Because the target methods only receive one datatype (an array), it was necessary to assert the datatype in situations where the original value was a union type.