### PR TITLE
do make use of target=es5 in tsconfig #241

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-json-api",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "description": "A JSON API client for ngrx",
   "module": "FESM/ngrx-json-api.es5.js",
   "es2015": "FESM/ngrx-json-api.js",

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es2015",
+        "target": "ES5",
         "module": "es2015",
         "sourceMap": true,
         "outDir": "./dist",


### PR DESCRIPTION
not sure what is going on with all the modules, but ES5 as default seems more reasonable currently. Angular CLI breaks otherwise.