### PR TITLE
support multiple instances of store #244

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-json-api",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-rc.1",
   "description": "A JSON API client for ngrx",
   "module": "FESM/ngrx-json-api.es5.js",
   "es2015": "FESM/ngrx-json-api.js",

--- a/spec/actions.spec.ts
+++ b/spec/actions.spec.ts
@@ -214,138 +214,138 @@ describe('Json Api Actions', () => {
   });
 
   it('should generate an api create init action using apiCreateInit', () => {
-    let action = new ApiPostInitAction({});
+    let action = new ApiPostInitAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_POST_INIT);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api create sueccess action using apiCreateSuccess', () => {
-    let action = new ApiPostSuccessAction({});
+    let action = new ApiPostSuccessAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_POST_SUCCESS);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api create fail action using apiCreateFail', () => {
-    let action = new ApiPostFailAction({});
+    let action = new ApiPostFailAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_POST_FAIL);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api read init action using apiReadInit', () => {
-    let action = new ApiGetInitAction({});
+    let action = new ApiGetInitAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_GET_INIT);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api read success action using apiReadSuccess', () => {
-    let action = new ApiGetSuccessAction({});
+    let action = new ApiGetSuccessAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_GET_SUCCESS);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api read fail action using apiReadFail', () => {
-    let action = new ApiGetFailAction({});
+    let action = new ApiGetFailAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_GET_FAIL);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api update init action using apiUpdateInit', () => {
-    let action = new ApiPatchInitAction({});
+    let action = new ApiPatchInitAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_PATCH_INIT);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an update success action using apiUpdateSuccess', () => {
-    let action = new ApiPatchSuccessAction({});
+    let action = new ApiPatchSuccessAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_PATCH_SUCCESS);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an update fail action using apiUpdateFail', () => {
-    let action = new ApiPatchFailAction({});
+    let action = new ApiPatchFailAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_PATCH_FAIL);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api delete init action using apiDeleteInit', () => {
-    let action = new ApiDeleteInitAction({});
+    let action = new ApiDeleteInitAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_DELETE_INIT);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api delete success action using apiDeleteSuccess', () => {
-    let action = new ApiDeleteSuccessAction({});
+    let action = new ApiDeleteSuccessAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_DELETE_SUCCESS);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api delete fail action using apiDeleteFail', () => {
-    let action = new ApiDeleteFailAction({});
+    let action = new ApiDeleteFailAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_DELETE_FAIL);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api commit init action using ApiApplyInit', () => {
-    let action = new ApiApplyInitAction({});
+    let action = new ApiApplyInitAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_INIT);
     expect(action.payload).toBeDefined();
   });
 
   it('should generate an api commit success action using ApiApplySuccess', () => {
-    let action = new ApiApplySuccessAction({});
+    let action = new ApiApplySuccessAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_SUCCESS);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api commit fail action using ApiApplyFail', () => {
-    let action = new ApiApplyFailAction({});
+    let action = new ApiApplyFailAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_APPLY_FAIL);
     expect(action.payload).toEqual({});
   });
 
   it('should generate an api rollback action using ApiRollbackInit', () => {
-    let action = new ApiRollbackAction();
+    let action = new ApiRollbackAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_ROLLBACK);
   });
 
   it('should generate a query store init action using LocalQueryInitAction', () => {
-    let action = new LocalQueryInitAction({});
+    let action = new LocalQueryInitAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.LOCAL_QUERY_INIT);
     expect(action.payload).toEqual({});
   });
 
   it('should generate a query store success action using LocalQuerySuccessAction', () => {
-    let action = new LocalQuerySuccessAction({});
+    let action = new LocalQuerySuccessAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.LOCAL_QUERY_SUCCESS);
     expect(action.payload).toEqual({});
   });
 
   it('should generate a delete store resource action using DeleteStoreResourceAction', () => {
-    let action = new DeleteStoreResourceAction({});
+    let action = new DeleteStoreResourceAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.DELETE_STORE_RESOURCE);
     expect(action.payload).toEqual({});
   });
 
   it('should generate a patch store resource action using PatchStoreResourceAction', () => {
-    let action = new PatchStoreResourceAction({});
+    let action = new PatchStoreResourceAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE);
     expect(action.payload).toEqual({});
   });
 
   it('should generate a new store resource action using NewStoreResourceAction', () => {
-    let action = new NewStoreResourceAction({});
+    let action = new NewStoreResourceAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.NEW_STORE_RESOURCE);
     expect(action.payload).toEqual({});
   });
 
   it('should generate a post store resource action using PostStoreResourceAction', () => {
-    let action = new PostStoreResourceAction({});
+    let action = new PostStoreResourceAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.POST_STORE_RESOURCE);
     expect(action.payload).toEqual({});
   });
 
   it('should generate a delete store resource action using RemoveQueryAction', () => {
-    let action = new RemoveQueryAction({});
+    let action = new RemoveQueryAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.REMOVE_QUERY);
     expect(action.payload).toEqual({});
   });
@@ -355,7 +355,7 @@ describe('Json Api Actions', () => {
       resourceId: null,
       errors: [],
       modificationType: 'SET',
-    });
+    }, 'testZone');
     expect(action.type).toEqual(
       NgrxJsonApiActionTypes.MODIFY_STORE_RESOURCE_ERRORS
     );
@@ -363,17 +363,17 @@ describe('Json Api Actions', () => {
   });
 
   it('should generate a compact store resource action using CompactStoreAction', () => {
-    let action = new CompactStoreAction({});
+    let action = new CompactStoreAction('testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.COMPACT_STORE);
   });
 
   it('should generate a clear store resource action using ClearStoreAction', () => {
-    let action = new ClearStoreAction({});
+    let action = new ClearStoreAction('testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.CLEAR_STORE);
   });
 
   it('should generate a refresh query action using ApiQueryRefreshAction', () => {
-    let action = new ApiQueryRefreshAction({});
+    let action = new ApiQueryRefreshAction({}, 'testZone');
     expect(action.type).toEqual(NgrxJsonApiActionTypes.API_QUERY_REFRESH);
   });
 });

--- a/spec/api.spec.ts
+++ b/spec/api.spec.ts
@@ -1,13 +1,10 @@
-import { async, inject, fakeAsync, tick, TestBed } from '@angular/core/testing';
+import {inject, TestBed} from '@angular/core/testing';
 
-import { HttpTestingController } from '@angular/common/http/testing';
-import { HttpRequest } from '@angular/common/http';
+import {HttpTestingController} from '@angular/common/http/testing';
 
-import { Observable } from 'rxjs/Observable';
+import {NgrxJsonApi} from '../src/api';
 
-import { NgrxJsonApi } from '../src/api';
-
-import { TestingModule, AlternativeTestingModule } from './testing.module';
+import {AlternativeTestingModule, TestingModule} from './testing.module';
 
 describe('ngrx json api', () => {
   let jsonapi: NgrxJsonApi;

--- a/spec/effects.spec.ts
+++ b/spec/effects.spec.ts
@@ -13,7 +13,6 @@ import { Store } from '@ngrx/store';
 import { provideMockActions } from '@ngrx/effects/testing';
 
 import { NgrxJsonApi } from '../src/api';
-import { NgrxJsonApiSelectors } from '../src/selectors';
 import { NgrxJsonApiEffects } from '../src/effects';
 
 import {
@@ -45,7 +44,6 @@ describe('NgrxJsonApiEffects', () => {
   let api: NgrxJsonApi;
   let store: Store<any>;
   let mockStoreLet: any;
-  let selectors: NgrxJsonApiSelectors;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -80,9 +78,9 @@ describe('NgrxJsonApiEffects', () => {
   };
   //
   it('should respond to successful POST_INIT action', () => {
-    let postinitAction = new ApiPostInitAction(resource);
+    let postinitAction = new ApiPostInitAction(resource, 'api');
     let payload = generatePayload(resource, 'POST');
-    let completed = new ApiPostSuccessAction(payload);
+    let completed = new ApiPostSuccessAction(payload, 'api');
     actions = hot('-a', { a: postinitAction });
     let response = cold('--a|', {
       a: new HttpResponse({
@@ -96,14 +94,14 @@ describe('NgrxJsonApiEffects', () => {
   });
 
   it('should respond to failed POST_INIT action', () => {
-    let postinitAction = new ApiPostInitAction(resource);
+    let postinitAction = new ApiPostInitAction(resource, 'api');
     let payload = generatePayload(resource, 'POST');
     let error = new HttpResponse({
       body: payload.jsonApiData,
       status: 400,
     });
     let completed = new ApiPostFailAction(
-      effects.toErrorPayload(payload.query, error)
+      effects.toErrorPayload(payload.query, error), 'api'
     );
     actions = hot('-a', { a: postinitAction });
     let response = cold('-#', {}, error);
@@ -113,9 +111,9 @@ describe('NgrxJsonApiEffects', () => {
   });
 
   it('should respond to successful PATCH_INIT action', () => {
-    let patchinitAction = new ApiPatchInitAction(resource);
+    let patchinitAction = new ApiPatchInitAction(resource, 'api');
     let payload = generatePayload(resource, 'PATCH');
-    let completed = new ApiPatchSuccessAction(payload);
+    let completed = new ApiPatchSuccessAction(payload, 'api');
     actions = hot('-a', { a: patchinitAction });
     let response = cold('--a|', {
       a: new HttpResponse({
@@ -129,14 +127,14 @@ describe('NgrxJsonApiEffects', () => {
   });
 
   it('should respond to failed PATCH_INIT action', () => {
-    let patchinitAction = new ApiPatchInitAction(resource);
+    let patchinitAction = new ApiPatchInitAction(resource, 'api');
     let payload = generatePayload(resource, 'PATCH');
     let error = new HttpResponse({
       body: payload.jsonApiData,
       status: 400,
     });
     let completed = new ApiPatchFailAction(
-      effects.toErrorPayload(payload.query, error)
+      effects.toErrorPayload(payload.query, error), 'api'
     );
     actions = hot('-a', { a: patchinitAction });
     let response = cold('--#', {}, error);
@@ -147,11 +145,11 @@ describe('NgrxJsonApiEffects', () => {
 
   it('should respond to successfull READ_INIT action', () => {
     let query = { type: 'Person', id: '1' };
-    let getinitAction = new ApiGetInitAction(query);
+    let getinitAction = new ApiGetInitAction(query, 'api');
     let completed = new ApiGetSuccessAction({
       jsonApiData: { data: query },
       query: query,
-    });
+    }, 'api');
     actions = hot('-a', { a: getinitAction });
     let response = cold('--a|', {
       a: new HttpResponse({ body: { data: query } }),
@@ -164,12 +162,12 @@ describe('NgrxJsonApiEffects', () => {
 
   it('should respond to failed READ_INIT action', () => {
     let query = { type: 'Person', id: '1' };
-    let getinitAction = new ApiGetInitAction(query);
+    let getinitAction = new ApiGetInitAction(query, 'api');
     let error = new HttpResponse({
       body: query,
       status: 400,
     });
-    let completed = new ApiGetFailAction(effects.toErrorPayload(query, error));
+    let completed = new ApiGetFailAction(effects.toErrorPayload(query, error), 'api');
     actions = hot('-a', { a: getinitAction });
     let response = cold('--#', {}, error);
     let expected = cold('---b', { b: completed });
@@ -177,13 +175,13 @@ describe('NgrxJsonApiEffects', () => {
     expect(effects.readResource$).toBeObservable(expected);
   });
 
-  it('should respond to successfull DELETE_INIT action', () => {
-    let deleteinitAction = new ApiDeleteInitAction(resource);
+  it('should respond to successful DELETE_INIT action', () => {
+    let deleteinitAction = new ApiDeleteInitAction(resource, 'api');
     let payload = generatePayload(resource, 'DELETE');
     let completed = new ApiDeleteSuccessAction({
       jsonApiData: payload.query,
       query: payload.query,
-    });
+    }, 'api');
     actions = hot('-a', { a: deleteinitAction });
     let response = cold('--a|', {
       a: new HttpResponse({
@@ -197,14 +195,14 @@ describe('NgrxJsonApiEffects', () => {
   });
 
   it('should respond to failed DELETE_INIT action', () => {
-    let deletefailAction = new ApiDeleteInitAction(resource);
+    let deletefailAction = new ApiDeleteInitAction(resource, 'api');
     let payload = generatePayload(resource, 'DELETE');
     let error = new HttpResponse({
       body: resource,
       status: 400,
     });
     let completed = new ApiDeleteFailAction(
-      effects.toErrorPayload(payload.query, error)
+      effects.toErrorPayload(payload.query, error), 'api'
     );
     actions = hot('-a', { a: deletefailAction });
     let response = cold('--#', {}, error);
@@ -219,11 +217,11 @@ describe('NgrxJsonApiEffects', () => {
       id: '1',
       queryId: 'someId',
     };
-    let localqueryinitAction = new LocalQueryInitAction(query);
+    let localqueryinitAction = new LocalQueryInitAction(query, 'api');
     let completed = new LocalQuerySuccessAction({
       jsonApiData: { data: query },
       query: query,
-    });
+    }, 'api');
     actions = hot('-a', { a: localqueryinitAction });
     let response = cold('--a', { a: query });
     let expected = cold('---b', { b: completed });
@@ -251,21 +249,21 @@ describe('NgrxJsonApiEffects', () => {
       type: 'Article',
       id: '2',
     };
-    let localqueryinitAction1 = new LocalQueryInitAction(query1);
-    let localqueryinitAction2 = new LocalQueryInitAction(query2);
+    let localqueryinitAction1 = new LocalQueryInitAction(query1, 'api');
+    let localqueryinitAction2 = new LocalQueryInitAction(query2, 'api');
     let completed1 = new LocalQuerySuccessAction({
       jsonApiData: { data: resource1 },
       query: query1,
-    });
+    }, 'api');
     // note that mock setup is not perfect, second query will get resource1 and resource2
     let completed2 = new LocalQuerySuccessAction({
       jsonApiData: { data: resource1 },
       query: query2,
-    });
+    }, 'api');
     let completed3 = new LocalQuerySuccessAction({
       jsonApiData: { data: resource2 },
       query: query2,
-    });
+    }, 'api');
     actions = hot('-a--b', {
       a: localqueryinitAction1,
       b: localqueryinitAction2,
@@ -295,12 +293,12 @@ describe('NgrxJsonApiEffects', () => {
       type: 'Article',
       id: '2',
     };
-    let localqueryinitAction = new LocalQueryInitAction(query);
-    let removeQueryAction = new RemoveQueryAction(query.queryId);
+    let localqueryinitAction = new LocalQueryInitAction(query, 'api');
+    let removeQueryAction = new RemoveQueryAction(query.queryId, 'api');
     let completed = new LocalQuerySuccessAction({
       jsonApiData: { data: resource1 },
       query: query,
-    });
+    }, 'api');
     actions = hot('-a--b', { a: localqueryinitAction, b: removeQueryAction });
     let response = cold('--a----b', { a: resource1, b: resource2 });
     let expected = cold('---a', { a: completed });

--- a/spec/pipes.spec.ts
+++ b/spec/pipes.spec.ts
@@ -1,41 +1,11 @@
-import { async, inject, fakeAsync, tick, TestBed } from '@angular/core/testing';
-
-import { Http, HttpModule } from '@angular/http';
-
-import { Store, StoreModule } from '@ngrx/store';
-import { EffectsModule } from '@ngrx/effects';
+import {inject, TestBed} from '@angular/core/testing';
 
 import * as _ from 'lodash';
+import {DenormaliseStoreResourcePipe, GetDenormalisedValuePipe, SelectStoreResourcePipe,} from '../src/pipes';
 
-import { NgrxJsonApi } from '../src/api';
-import { NgrxJsonApiService } from '../src/services';
-import { NgrxJsonApiSelectors } from '../src/selectors';
-import { NgrxJsonApiEffects } from '../src/effects';
-import {
-  DenormaliseStoreResourcePipe,
-  GetDenormalisedValuePipe,
-  SelectStoreResourcePipe,
-} from '../src/pipes';
+import {denormaliseStoreResource,} from '../src/utils';
 
-import {
-  initialNgrxJsonApiState,
-  NgrxJsonApiStoreReducer,
-} from '../src/reducers';
-
-import {
-  NGRX_JSON_API_CONFIG,
-  apiFactory,
-  selectorsFactory,
-  serviceFactory,
-} from '../src/module';
-
-import {
-  denormaliseStoreResource,
-  updateStoreDataFromPayload,
-} from '../src/utils';
-
-import { TestingModule } from './testing.module';
-import { testPayload, resourceDefinitions } from './test_utils';
+import {TestingModule} from './testing.module';
 
 describe('Pipes', () => {
   let pipe;

--- a/spec/services.spec.ts
+++ b/spec/services.spec.ts
@@ -1,39 +1,15 @@
-import { async, inject, fakeAsync, tick, TestBed } from '@angular/core/testing';
+import {inject, TestBed} from '@angular/core/testing';
 
 import * as _ from 'lodash';
 
-import { Http, HttpModule } from '@angular/http';
+import {Observable} from 'rxjs/Observable';
+import {NgrxJsonApiService} from '../src/services';
 
-import { Observable } from 'rxjs/Observable';
-import { Store, StoreModule } from '@ngrx/store';
-import { EffectsModule } from '@ngrx/effects';
+import {denormaliseStoreResource,} from '../src/utils';
 
-import { NgrxJsonApi } from '../src/api';
-import { NgrxJsonApiService } from '../src/services';
-import { NgrxJsonApiSelectors } from '../src/selectors';
-import { NgrxJsonApiEffects } from '../src/effects';
-import { NgrxJsonApiModule } from '../src/module';
-
-import {
-  initialNgrxJsonApiState,
-  NgrxJsonApiStoreReducer,
-} from '../src/reducers';
-
-import {
-  NGRX_JSON_API_CONFIG,
-  apiFactory,
-  selectorsFactory,
-  serviceFactory,
-} from '../src/module';
-
-import {
-  denormaliseStoreResource,
-  updateStoreDataFromPayload,
-} from '../src/utils';
-
-import { StoreResource } from '../src/interfaces';
-import { TestingModule } from './testing.module';
-import { testPayload, resourceDefinitions } from './test_utils';
+import {StoreResource} from '../src/interfaces';
+import {TestingModule} from './testing.module';
+import {resourceDefinitions} from './test_utils';
 
 describe('NgrxJsonApiService', () => {
   let service: NgrxJsonApiService;
@@ -132,7 +108,7 @@ describe('NgrxJsonApiService', () => {
       });
     });
 
-    it('remove the query from the state after unsubscribing', () => {
+   it('remove the query from the state after unsubscribing', () => {
       let query = {
         type: 'Article',
         queryId: '22',

--- a/spec/testing.module.ts
+++ b/spec/testing.module.ts
@@ -1,23 +1,17 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { HttpClient, HttpClientModule } from '@angular/common/http';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-
-import { Observable } from 'rxjs/Observable';
+import {HttpClientModule} from '@angular/common/http';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/observable/throw';
 
-import { StoreModule } from '@ngrx/store';
-import { EffectsModule } from '@ngrx/effects';
+import {StoreModule} from '@ngrx/store';
+import {EffectsModule} from '@ngrx/effects';
+import {initialNgrxJsonApiState} from '../src/reducers';
+import {NgrxJsonApiModule} from '../src/module';
+import {updateStoreDataFromPayload} from '../src/utils';
 
-import { NgrxJsonApi } from '../src/api';
-import { initialNgrxJsonApiState } from '../src/reducers';
-import { NgrxJsonApiModule } from '../src/module';
-import { updateStoreDataFromPayload } from '../src/utils';
-import { Payload, Query } from '../src/interfaces';
-import { NgrxJsonApiEffects } from '../src/effects';
-
-import { testPayload, resourceDefinitions } from './test_utils';
+import {resourceDefinitions, testPayload} from './test_utils';
 
 let queries = {
   '1': {
@@ -48,14 +42,16 @@ let queries = {
 
 let initialState = {
   NgrxJsonApi: {
-    api: {
-      ...{},
-      ...initialNgrxJsonApiState,
-      ...{
-        data: updateStoreDataFromPayload({}, testPayload),
-        queries: queries,
+    zones: {
+      default: {
+        ...{},
+        ...initialNgrxJsonApiState,
+        ...{
+          data: updateStoreDataFromPayload({}, testPayload),
+          queries: queries,
+        },
       },
-    },
+    }
   },
 };
 

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -16,7 +16,7 @@ import {
   insertStoreResource,
   isEqualResource,
   removeQuery,
-  rollbackStoreResources,
+  rollbackStoreResources, setIn,
   sortPendingChanges,
   toResourceIdentifier,
   updateQueryErrors,
@@ -31,7 +31,7 @@ import {
   updateStoreResource,
 } from '../src/utils';
 //
-import { initialNgrxJsonApiState } from '../src/reducers';
+import {initialNgrxJsonApiState, initialNgrxJsonApiZone} from '../src/reducers';
 //
 import {
   NgrxJsonApiStoreData,
@@ -91,9 +91,59 @@ deepFreeze(initialNgrxJsonApiState);
 //     });
 // });
 
+
+describe('setIn', () => {
+  it('should do nothing if value not changed', () => {
+    let a = {
+      x: 1,
+      y: 2
+    };
+    let result = setIn(a, "x", 1);
+    expect(result === a).toBeTruthy();
+  });
+
+  it('should change value', () => {
+    let a = {
+      x: 1,
+      y: 2
+    };
+    let result = setIn(a, "x", 3);
+    expect(result === a).toBeFalsy();
+    expect(result.x).toEqual(3);
+    expect(result.y).toEqual(2);
+  });
+
+  it('should change value', () => {
+    let a = {
+      x: 1,
+      y: 2
+    };
+    let result = setIn(a, "x", 3);
+    expect(result === a).toBeFalsy();
+    expect(result.x).toEqual(3);
+    expect(result.y).toEqual(2);
+  });
+
+  it('should change nested value', () => {
+    let a = {
+      x: {
+        a: '1'
+      },
+      y: {
+        b: '2'
+      }
+    };
+    let result = setIn(a, "x.a", 3);
+    expect(result === a).toBeFalsy();
+    expect(result.x === a.x).toBeFalsy();
+    expect(result.y === a.y).toBeTruthy();
+    expect(result.x.a).toEqual(3);
+  });
+}
+
 describe('denormalise and denormaliseObject', () => {
   let storeData = updateStoreDataFromPayload(
-    initialNgrxJsonApiState.data,
+    initialNgrxJsonApiZone.data,
     testPayload
   );
   deepFreeze(storeData);
@@ -238,7 +288,7 @@ describe('getDenormalisedPath', () => {
 
 describe('getDenormalisedValue', () => {
   let storeData = updateStoreDataFromPayload(
-    initialNgrxJsonApiState.data,
+    initialNgrxJsonApiZone.data,
     testPayload
   );
   let denormalisedR = denormaliseStoreResource(
@@ -912,7 +962,6 @@ describe('rollbackStoreResources', () => {
   };
   it('should delete the resource if a persistedResource does not exist', () => {
     let newState = rollbackStoreResources(storeData);
-    // console.log(newState);
     expect(newState['Article']['1']).not.toBeDefined();
     expect(newState['Comment']['1']).toBeDefined();
     expect(newState['Comment']['1'].resource.attributes.title).toEqual('C11');
@@ -1019,7 +1068,7 @@ describe('updateStoreDataFromResource', () => {
 describe('updateStoreDataFromPayload', () => {
   it('should update the store data given a JsonApiDocument', () => {
     let newState = updateStoreDataFromPayload(
-      initialNgrxJsonApiState.data,
+      initialNgrxJsonApiZone.data,
       documentPayload
     );
     expect(newState['Article']).toBeDefined();
@@ -1161,7 +1210,7 @@ describe('toResourceIdentifier', () => {
 
 describe('getResourceFieldValueFromPath', () => {
   let storeData = updateStoreDataFromPayload(
-    initialNgrxJsonApiState.data,
+    initialNgrxJsonApiZone.data,
     testPayload
   );
 
@@ -1294,7 +1343,7 @@ describe('getResourceFieldValueFromPath', () => {
 
 describe('filterResources (TODO: test remaining types)', () => {
   let storeData = updateStoreDataFromPayload(
-    initialNgrxJsonApiState.data,
+    initialNgrxJsonApiZone.data,
     testPayload
   );
 
@@ -1560,7 +1609,6 @@ describe('getPendingChanges', () => {
     state['Article']['2'].state = 'UPDATED';
     let changes = getPendingChanges(state, undefined, undefined, true);
     expect(changes.length).toEqual(1);
-    console.log(changes);
     expect(changes[0].id).toEqual('2');
   });
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -57,148 +57,158 @@ export interface ApiApplyInitPayload {
 
 export interface ApiApplyRollbackPayload extends ApiApplyInitPayload {}
 
-export class ApiApplyInitAction implements Action {
+export abstract class NgrxJsonApiAction implements Action{
+  abstract zoneId?: string;
+  abstract type: string;
+  constructor(){
+  }
+}
+
+export class ApiApplyInitAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_APPLY_INIT;
-  constructor(public payload: ApiApplyInitPayload) {}
+  constructor(public payload: ApiApplyInitPayload, public zoneId: string) {
+    super();
+  }
 }
 
-export class ApiApplySuccessAction implements Action {
+export class ApiApplySuccessAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_APPLY_SUCCESS;
-  constructor(public payload: Array<Action>) {}
+  constructor(public payload: Array<Action>, public zoneId: string) {super();}
 }
 
-export class ApiApplyFailAction implements Action {
+export class ApiApplyFailAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_APPLY_FAIL;
-  constructor(public payload: Array<Action>) {}
+  constructor(public payload: Array<Action>, public zoneId: string) {super();}
 }
 
-export class ApiPostInitAction implements Action {
+export class ApiPostInitAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_POST_INIT;
-  constructor(public payload: Resource) {}
+  constructor(public payload: Resource, public zoneId: string) {super();}
 }
 
-export class ApiPostSuccessAction implements Action {
+export class ApiPostSuccessAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_POST_SUCCESS;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class ApiPostFailAction implements Action {
+export class ApiPostFailAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_POST_FAIL;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class ApiDeleteInitAction implements Action {
+export class ApiDeleteInitAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_DELETE_INIT;
-  constructor(public payload: ResourceIdentifier) {}
+  constructor(public payload: ResourceIdentifier, public zoneId: string) {super();}
 }
 
-export class ApiDeleteSuccessAction implements Action {
+export class ApiDeleteSuccessAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_DELETE_SUCCESS;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class ApiDeleteFailAction implements Action {
+export class ApiDeleteFailAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_DELETE_FAIL;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class ApiGetInitAction implements Action {
+export class ApiGetInitAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_GET_INIT;
-  constructor(public payload: Query) {}
+  constructor(public payload: Query, public zoneId: string) {super();}
 }
 
-export class ApiGetSuccessAction implements Action {
+export class ApiGetSuccessAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_GET_SUCCESS;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class ApiGetFailAction implements Action {
+export class ApiGetFailAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_GET_FAIL;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class ApiRollbackAction implements Action {
+export class ApiRollbackAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_ROLLBACK;
-  constructor(public payload: ApiApplyRollbackPayload) {}
+  constructor(public payload: ApiApplyRollbackPayload, public zoneId: string) {super();}
 }
 
-export class ApiPatchInitAction implements Action {
+export class ApiPatchInitAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_PATCH_INIT;
-  constructor(public payload: Resource) {}
+  constructor(public payload: Resource, public zoneId: string) {super();}
 }
 
-export class ApiPatchSuccessAction implements Action {
+export class ApiPatchSuccessAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_PATCH_SUCCESS;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class ApiPatchFailAction implements Action {
+export class ApiPatchFailAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_PATCH_FAIL;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class DeleteStoreResourceAction implements Action {
+export class DeleteStoreResourceAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.DELETE_STORE_RESOURCE;
-  constructor(public payload: ResourceIdentifier) {}
+  constructor(public payload: ResourceIdentifier, public zoneId: string) {super();}
 }
 
-export class PatchStoreResourceAction implements Action {
+export class PatchStoreResourceAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.PATCH_STORE_RESOURCE;
-  constructor(public payload: Resource) {}
+  constructor(public payload: Resource, public zoneId: string) {super();}
 }
 
-export class NewStoreResourceAction implements Action {
+export class NewStoreResourceAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.NEW_STORE_RESOURCE;
-  constructor(public payload: Resource) {}
+  constructor(public payload: Resource, public zoneId: string) {super();}
 }
 
-export class PostStoreResourceAction implements Action {
+export class PostStoreResourceAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.POST_STORE_RESOURCE;
-  constructor(public payload: Resource) {}
+  constructor(public payload: Resource, public zoneId: string) {super();}
 }
 
-export class RemoveQueryAction implements Action {
+export class RemoveQueryAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.REMOVE_QUERY;
-  constructor(public payload: string) {}
+  constructor(public payload: string, public zoneId: string) {super();}
 }
 
-export class LocalQueryInitAction implements Action {
+export class LocalQueryInitAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.LOCAL_QUERY_INIT;
-  constructor(public payload: Query) {}
+  constructor(public payload: Query, public zoneId: string) {super();}
 }
 
-export class LocalQuerySuccessAction implements Action {
+export class LocalQuerySuccessAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.LOCAL_QUERY_SUCCESS;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class LocalQueryFailAction implements Action {
+export class LocalQueryFailAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.LOCAL_QUERY_FAIL;
-  constructor(public payload: Payload) {}
+  constructor(public payload: Payload, public zoneId: string) {super();}
 }
 
-export class CompactStoreAction implements Action {
+export class CompactStoreAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.COMPACT_STORE;
-  constructor() {}
+  constructor(public zoneId: string) {super();}
 }
 
-export class ClearStoreAction implements Action {
+export class ClearStoreAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.CLEAR_STORE;
-  constructor() {}
+  constructor(public zoneId: string) {super();}
 }
 
-export class ApiQueryRefreshAction implements Action {
+export class ApiQueryRefreshAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.API_QUERY_REFRESH;
-  constructor(public payload: string) {
+  constructor(public payload: string, public zoneId: string) {
+    super();
     if (!payload) {
       throw new Error('no query id provided for ApiQueryRefreshAction');
     }
   }
 }
 
-export class ModifyStoreResourceErrorsAction implements Action {
+export class ModifyStoreResourceErrorsAction extends NgrxJsonApiAction {
   readonly type = NgrxJsonApiActionTypes.MODIFY_STORE_RESOURCE_ERRORS;
-  constructor(public payload: ModifyStoreResourceErrorsPayload) {}
+  constructor(public payload: ModifyStoreResourceErrorsPayload, public zoneId: string) {super();}
 }
 
 export type NgrxJsonApiActions =

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
 export {
   FindOptions,
   NgrxJsonApiService,
+  NgrxJsonApiZoneService,
   PutQueryOptions,
   PostResourceOptions,
   PatchResourceOptions,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,8 @@
 import { Observable } from 'rxjs/Observable';
 import { AnonymousSubscription } from 'rxjs/Subscription';
 
+export const NGRX_JSON_API_DEFAULT_ZONE = 'default';
+
 export enum Direction {
   ASC,
   DESC,
@@ -63,6 +65,17 @@ export interface NgrxJsonApiConfig {
   applyEnabled?: boolean;
 }
 
+export interface NgrxJsonApiState {
+  zones: NgrxJsonApiZones
+}
+
+export interface NgrxJsonApiZones {
+  [id: string]: NgrxJsonApiZone;
+}
+
+/**
+ * deprecated, mae use of NgrxJsonApiZone instead
+ */
 export interface NgrxJsonApiStore {
   data: NgrxJsonApiStoreData;
   queries: NgrxJsonApiStoreQueries;
@@ -71,6 +84,10 @@ export interface NgrxJsonApiStore {
   isUpdating: number;
   isDeleting: number;
   isApplying: number;
+}
+
+export interface NgrxJsonApiZone extends NgrxJsonApiStore{
+
 }
 
 export interface NgrxJsonApiStoreData {

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,7 +7,6 @@ import { EffectsModule } from '@ngrx/effects';
 
 import { NgrxJsonApi } from './api';
 import { NgrxJsonApiEffects } from './effects';
-import { NgrxJsonApiSelectors } from './selectors';
 import { NgrxJsonApiService } from './services';
 import { reducer } from './reducers';
 import {
@@ -17,6 +16,7 @@ import {
 } from './pipes';
 
 import { NgrxJsonApiConfig } from './interfaces';
+import {NgrxJsonApiSelectors} from "./selectors";
 
 export const NGRX_JSON_API_CONFIG = new OpaqueToken('NGRX_JSON_API_CONFIG');
 
@@ -24,15 +24,19 @@ export function apiFactory(http: HttpClient, config: NgrxJsonApiConfig) {
   return new NgrxJsonApi(http, config);
 }
 
-export function selectorsFactory(config: NgrxJsonApiConfig) {
-  return new NgrxJsonApiSelectors(config);
+/**
+ * Deprecated, do not use any longer
+ */
+export function selectorsFactory() {
+  return new NgrxJsonApiSelectors();
 }
+
 
 export function serviceFactory(
   store: Store<any>,
-  selectors: NgrxJsonApiSelectors
+  config: NgrxJsonApiConfig
 ) {
-  return new NgrxJsonApiService(store, selectors);
+  return new NgrxJsonApiService(store, config);
 }
 
 export function configure(config: NgrxJsonApiConfig): Array<any> {
@@ -45,12 +49,11 @@ export function configure(config: NgrxJsonApiConfig): Array<any> {
     {
       provide: NgrxJsonApiSelectors,
       useFactory: selectorsFactory,
-      deps: [NGRX_JSON_API_CONFIG],
     },
     {
       provide: NgrxJsonApiService,
       useFactory: serviceFactory,
-      deps: [Store, NgrxJsonApiSelectors],
+      deps: [Store, NGRX_JSON_API_CONFIG],
     },
     {
       provide: NGRX_JSON_API_CONFIG,

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,39 +1,43 @@
 import * as _ from 'lodash';
 
-import { Observable } from 'rxjs/Observable';
+import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/finally';
 
-import { Store } from '@ngrx/store';
+import {Store} from '@ngrx/store';
 
-import { NgrxJsonApiSelectors } from './selectors';
+import {
+  selectManyQueryResult, selectNgrxJsonApiDefaultZone, selectNgrxJsonApiZone,
+  selectOneQueryResult,
+  selectStoreResource
+} from './selectors';
 import {
   ApiApplyInitAction,
-  ApiPostInitAction,
+  ApiDeleteInitAction,
   ApiGetInitAction,
   ApiPatchInitAction,
-  ApiDeleteInitAction,
+  ApiPostInitAction,
+  ApiQueryRefreshAction,
+  ClearStoreAction,
+  CompactStoreAction,
   DeleteStoreResourceAction,
+  LocalQueryInitAction,
+  ModifyStoreResourceErrorsAction,
+  NewStoreResourceAction,
   PatchStoreResourceAction,
   PostStoreResourceAction,
   RemoveQueryAction,
-  LocalQueryInitAction,
-  ClearStoreAction,
-  CompactStoreAction,
-  ApiQueryRefreshAction,
-  ModifyStoreResourceErrorsAction,
-  NewStoreResourceAction,
 } from './actions';
 import {
+  ManyQueryResult, NGRX_JSON_API_DEFAULT_ZONE, NgrxJsonApiConfig,
   NgrxJsonApiStore,
   NgrxJsonApiStoreData,
-  Resource,
-  ResourceIdentifier,
+  OneQueryResult,
   Query,
   QueryResult,
-  OneQueryResult,
-  ManyQueryResult,
-  StoreResource,
+  Resource,
   ResourceError,
+  ResourceIdentifier,
+  StoreResource,
 } from './interfaces';
 import {
   denormaliseStoreResource,
@@ -85,38 +89,13 @@ export interface Options {
   resourceId?: ResourceIdentifier;
 }
 
-export class NgrxJsonApiService {
-  private test = true;
+/**
+ * Represents an isolated area in the store with its own set of resources and queries.
+ * 'api' is the default zone that already historically has been put beneath NgrxJsonApi within the store.
+ */
+export class NgrxJsonApiZoneService {
 
-  /**
-   * Keeps current snapshot of the store to allow fast access to resources.
-   */
-  private _storeSnapshot: NgrxJsonApiStore;
-
-  constructor(
-    private store: Store<any>,
-    private selectors: NgrxJsonApiSelectors
-  ) {}
-
-  public findOne(options: FindOptions): Observable<OneQueryResult> {
-    return <Observable<OneQueryResult>>this.findInternal(options, false);
-  }
-
-  public findMany(options: FindOptions): Observable<ManyQueryResult> {
-    return <Observable<ManyQueryResult>>this.findInternal(options, true);
-  }
-
-  public get storeSnapshot() {
-    if (!this._storeSnapshot) {
-      this.store
-        .let(this.selectors.getNgrxJsonApiStore$())
-        .subscribe(it => (this._storeSnapshot = it as NgrxJsonApiStore));
-
-      if (!this._storeSnapshot) {
-        throw new Error('failed to initialize store snapshot');
-      }
-    }
-    return this._storeSnapshot;
+  constructor(protected zoneId: string, protected store: Store<any>) {
   }
 
   /**
@@ -137,24 +116,227 @@ export class NgrxJsonApiService {
     }
 
     if (fromServer) {
-      this.store.dispatch(new ApiGetInitAction(query));
+      this.store.dispatch(new ApiGetInitAction(query, this.zoneId));
     } else {
-      this.store.dispatch(new LocalQueryInitAction(query));
+      this.store.dispatch(new LocalQueryInitAction(query, this.zoneId));
     }
   }
 
   public refreshQuery(queryId: string) {
-    this.store.dispatch(new ApiQueryRefreshAction(queryId));
+    this.store.dispatch(new ApiQueryRefreshAction(queryId, this.zoneId));
   }
 
   public removeQuery(queryId: string) {
-    this.store.dispatch(new RemoveQueryAction(queryId));
+    this.store.dispatch(new RemoveQueryAction(queryId, this.zoneId));
   }
 
-  private findInternal(
-    options: FindOptions,
-    multi: boolean
-  ): Observable<QueryResult> {
+  /**
+   * Selects the data of the given query.
+   *
+   * @param queryId
+   * @returns observable holding the data as array of resources.
+   */
+  public selectManyResults(queryId: string, denormalize = false): Observable<ManyQueryResult> {
+    return this.store.let(selectNgrxJsonApiZone(this.zoneId)).let(selectManyQueryResult(queryId, denormalize));
+  }
+
+  /**
+   * Selects the data of the given query.
+   *
+   * @param queryId
+   * @returns observable holding the data as array of resources.
+   */
+  public selectOneResults(queryId: string, denormalize = false): Observable<OneQueryResult> {
+    return this.store.let(selectNgrxJsonApiZone(this.zoneId)).let(selectOneQueryResult(queryId, denormalize));
+  }
+
+  /**
+   * @param identifier of the resource
+   * @returns observable of the resource
+   */
+  public selectStoreResource(identifier: ResourceIdentifier): Observable<StoreResource> {
+    return this.store.let(selectNgrxJsonApiZone(this.zoneId)).let(selectStoreResource(identifier));
+  }
+
+
+  /**
+   * Updates the given resource in the store with the provided data.
+   * Use commit() to send the changes to the remote JSON API endpoint.
+   *
+   * @param resource
+   */
+  public patchResource(options: PatchResourceOptions) {
+    let resource = options.resource;
+    let toRemote = _.isUndefined(options.toRemote) ? false : options.toRemote;
+
+    if (toRemote) {
+      this.store.dispatch(new ApiPatchInitAction(resource, this.zoneId));
+    } else {
+      this.store.dispatch(new PatchStoreResourceAction(resource, this.zoneId));
+    }
+  }
+
+  /**
+   * Creates a new resources that is hold locally in the store
+   * and my later be posted.
+   *
+   * @param resource
+   */
+  public newResource(options: NewResourceOptions) {
+    let resource = options.resource;
+    this.store.dispatch(new NewStoreResourceAction(resource, this.zoneId));
+  }
+
+  /**
+   * Adds the given resource to the store. Any already existing
+   * resource with the same id gets replaced. Use commit() to send
+   * the changes to the remote JSON API endpoint.
+   *
+   * @param resource
+   */
+  public postResource(options: PostResourceOptions) {
+    let resource = options.resource;
+    let toRemote = _.isUndefined(options.toRemote) ? false : options.toRemote;
+
+    if (toRemote) {
+      this.store.dispatch(new ApiPostInitAction(resource, this.zoneId));
+    } else {
+      this.store.dispatch(new PostStoreResourceAction(resource, this.zoneId));
+    }
+  }
+
+  /**
+   * Marks the given resource for deletion.
+   *
+   * @param resourceId
+   */
+  public deleteResource(options: DeleteResourceOptions) {
+    let resourceId = options.resourceId;
+    let toRemote = _.isUndefined(options.toRemote) ? false : options.toRemote;
+
+    if (toRemote) {
+      this.store.dispatch(new ApiDeleteInitAction(resourceId, this.zoneId));
+    } else {
+      this.store.dispatch(new DeleteStoreResourceAction(resourceId, this.zoneId));
+    }
+  }
+
+  /**
+   * Applies all pending changes to the remote JSON API endpoint.
+   */
+  public apply() {
+    this.store.dispatch(new ApiApplyInitAction({}, this.zoneId));
+  }
+
+  /**
+   * Clear all the contents from the store.
+   */
+  public clear() {
+    this.store.dispatch(new ClearStoreAction(this.zoneId));
+  }
+
+  /**
+   * Compacts the store by removing unreferences and unchanges resources.
+   */
+  public compact() {
+    this.store.dispatch(new CompactStoreAction(this.zoneId));
+  }
+
+  /**
+   * Adds the given errors to the resource with the given id.
+   * @param id
+   * @param errors
+   */
+  public addResourceErrors(id: ResourceIdentifier,
+                           errors: Array<ResourceError>) {
+    this.store.dispatch(
+      new ModifyStoreResourceErrorsAction({
+        resourceId: id,
+        errors: errors,
+        modificationType: 'ADD',
+      }, this.zoneId)
+    );
+  }
+
+  /**
+   * Removes the given errors to the resource with the given id.
+   * @param id
+   * @param errors
+   */
+  public removeResourceErrors(id: ResourceIdentifier,
+                              errors: Array<ResourceError>) {
+    this.store.dispatch(
+      new ModifyStoreResourceErrorsAction({
+        resourceId: id,
+        errors: errors,
+        modificationType: 'REMOVE',
+      }, this.zoneId)
+    );
+  }
+
+  /**
+   * Sets the given errors to the resource with the given id.
+   * @param id
+   * @param errors
+   */
+  public setResourceErrors(id: ResourceIdentifier,
+                           errors: Array<ResourceError>) {
+    this.store.dispatch(
+      new ModifyStoreResourceErrorsAction({
+        resourceId: id,
+        errors: errors,
+        modificationType: 'SET',
+      }, this.zoneId)
+    );
+  }
+
+}
+
+
+export class NgrxJsonApiService extends NgrxJsonApiZoneService {
+  private test = true;
+
+  /**
+   * Keeps current snapshot of the store to allow fast access to resources.
+   */
+  private _storeSnapshot: NgrxJsonApiStore;
+
+  constructor(store: Store<any>, private config: NgrxJsonApiConfig) {
+    super(NGRX_JSON_API_DEFAULT_ZONE, store);
+  }
+
+  public getDefaultZone(): NgrxJsonApiZoneService{
+    return this;
+  }
+
+  public getZone(zoneId: string): NgrxJsonApiZoneService{
+    return new NgrxJsonApiZoneService(zoneId, this.store);
+  }
+
+  public findOne(options: FindOptions): Observable<OneQueryResult> {
+    return <Observable<OneQueryResult>>this.findInternal(options, false);
+  }
+
+  public findMany(options: FindOptions): Observable<ManyQueryResult> {
+    return <Observable<ManyQueryResult>>this.findInternal(options, true);
+  }
+
+  public get storeSnapshot() {
+    if (!this._storeSnapshot) {
+      this.store
+        .let(selectNgrxJsonApiDefaultZone())
+        .subscribe(it => (this._storeSnapshot = it as NgrxJsonApiStore));
+
+      if (!this._storeSnapshot) {
+        throw new Error('failed to initialize store snapshot');
+      }
+    }
+    return this._storeSnapshot;
+  }
+
+
+  private findInternal(options: FindOptions,
+                       multi: boolean): Observable<QueryResult> {
     let query = options.query;
     let fromServer = _.isUndefined(options.fromServer)
       ? true
@@ -165,20 +347,18 @@ export class NgrxJsonApiService {
 
     let newQuery: Query;
     if (!query.queryId) {
-      newQuery = { ...query, queryId: this.uuid() };
+      newQuery = {...query, queryId: this.uuid()};
     } else {
       newQuery = query;
     }
 
-    this.putQuery({ query: newQuery, fromServer });
-
+    this.putQuery({query: newQuery, fromServer});
     let queryResult$: Observable<QueryResult>;
     if (multi) {
       queryResult$ = this.selectManyResults(newQuery.queryId, denormalise);
     } else {
       queryResult$ = this.selectOneResults(newQuery.queryId, denormalise);
     }
-
     return <Observable<QueryResult>>queryResult$.finally(() =>
       this.removeQuery(newQuery.queryId)
     );
@@ -222,63 +402,16 @@ export class NgrxJsonApiService {
     return null;
   }
 
-  /**
-   * Selects the data of the given query.
-   *
-   * @param queryId
-   * @returns observable holding the data as array of resources.
-   */
-  public selectManyResults(
-    queryId: string,
-    denormalize = false
-  ): Observable<ManyQueryResult> {
-    let queryResult$ = this.store
-      .let(this.selectors.getNgrxJsonApiStore$())
-      .let(this.selectors.getManyResults$(queryId, denormalize));
-    return queryResult$;
-  }
 
-  /**
-   * Selects the data of the given query.
-   *
-   * @param queryId
-   * @returns observable holding the data as array of resources.
-   */
-  public selectOneResults(
-    queryId: string,
-    denormalize = false
-  ): Observable<OneQueryResult> {
-    let queryResult$ = this.store
-      .let(this.selectors.getNgrxJsonApiStore$())
-      .let(this.selectors.getOneResult$(queryId, denormalize));
-    return queryResult$ as Observable<OneQueryResult>;
-  }
-
-  /**
-   * @param identifier of the resource
-   * @returns observable of the resource
-   */
-  public selectStoreResource(
-    identifier: ResourceIdentifier
-  ): Observable<StoreResource> {
-    return this.store
-      .let(this.selectors.getNgrxJsonApiStore$())
-      .let(this.selectors.getStoreResource$(identifier));
-  }
-
-  public denormaliseResource(
-    storeResource$: Observable<StoreResource> | Observable<StoreResource[]>
-  ): Observable<StoreResource> | Observable<StoreResource[]> {
+  public denormaliseResource(storeResource$: Observable<StoreResource> | Observable<StoreResource[]>): Observable<StoreResource> | Observable<StoreResource[]> {
     return <
       | Observable<StoreResource>
       | Observable<StoreResource[]>>storeResource$.combineLatest(
       this.store
-        .let(this.selectors.getNgrxJsonApiStore$())
-        .let(this.selectors.getStoreData$()),
-      (
-        storeResource: StoreResource | StoreResource[],
-        storeData: NgrxJsonApiStoreData
-      ) => {
+        .let(selectNgrxJsonApiZone(this.zoneId))
+        .map(state => state.data),
+      (storeResource: StoreResource | StoreResource[],
+       storeData: NgrxJsonApiStoreData) => {
         if (_.isArray(storeResource)) {
           return denormaliseStoreResources(
             storeResource as Array<StoreResource>,
@@ -294,164 +427,29 @@ export class NgrxJsonApiService {
 
   public getDenormalisedPath(path: string, resourceType: string): string {
     let pathSeparator = _.get(
-      this.selectors.config,
+      this.config,
       'filteringConfig.pathSeparator'
     ) as string;
     return getDenormalisedPath(
       path,
       resourceType,
-      this.selectors.config.resourceDefinitions,
+      this.config.resourceDefinitions,
       pathSeparator
     );
   }
 
   public getDenormalisedValue(path: string, storeResource: StoreResource): any {
     let pathSeparator = _.get(
-      this.selectors.config,
+      this.config,
       'filteringConfig.pathSeparator'
     ) as string;
     return getDenormalisedValue(
       path,
       storeResource,
-      this.selectors.config.resourceDefinitions,
+      this.config.resourceDefinitions,
       pathSeparator
     );
   }
 
-  /**
-   * Updates the given resource in the store with the provided data.
-   * Use commit() to send the changes to the remote JSON API endpoint.
-   *
-   * @param resource
-   */
-  public patchResource(options: PatchResourceOptions) {
-    let resource = options.resource;
-    let toRemote = _.isUndefined(options.toRemote) ? false : options.toRemote;
 
-    if (toRemote) {
-      this.store.dispatch(new ApiPatchInitAction(resource));
-    } else {
-      this.store.dispatch(new PatchStoreResourceAction(resource));
-    }
-  }
-
-  /**
-   * Creates a new resources that is hold locally in the store
-   * and my later be posted.
-   *
-   * @param resource
-   */
-  public newResource(options: NewResourceOptions) {
-    let resource = options.resource;
-    this.store.dispatch(new NewStoreResourceAction(resource));
-  }
-
-  /**
-   * Adds the given resource to the store. Any already existing
-   * resource with the same id gets replaced. Use commit() to send
-   * the changes to the remote JSON API endpoint.
-   *
-   * @param resource
-   */
-  public postResource(options: PostResourceOptions) {
-    let resource = options.resource;
-    let toRemote = _.isUndefined(options.toRemote) ? false : options.toRemote;
-
-    if (toRemote) {
-      this.store.dispatch(new ApiPostInitAction(resource));
-    } else {
-      this.store.dispatch(new PostStoreResourceAction(resource));
-    }
-  }
-
-  /**
-   * Marks the given resource for deletion.
-   *
-   * @param resourceId
-   */
-  public deleteResource(options: DeleteResourceOptions) {
-    let resourceId = options.resourceId;
-    let toRemote = _.isUndefined(options.toRemote) ? false : options.toRemote;
-
-    if (toRemote) {
-      this.store.dispatch(new ApiDeleteInitAction(resourceId));
-    } else {
-      this.store.dispatch(new DeleteStoreResourceAction(resourceId));
-    }
-  }
-
-  /**
-   * Applies all pending changes to the remote JSON API endpoint.
-   */
-  public apply() {
-    this.store.dispatch(new ApiApplyInitAction({}));
-  }
-
-  /**
-   * Clear all the contents from the store.
-   */
-  public clear() {
-    this.store.dispatch(new ClearStoreAction());
-  }
-
-  /**
-   * Compacts the store by removing unreferences and unchanges resources.
-   */
-  public compact() {
-    this.store.dispatch(new CompactStoreAction());
-  }
-
-  /**
-   * Adds the given errors to the resource with the given id.
-   * @param id
-   * @param errors
-   */
-  public addResourceErrors(
-    id: ResourceIdentifier,
-    errors: Array<ResourceError>
-  ) {
-    this.store.dispatch(
-      new ModifyStoreResourceErrorsAction({
-        resourceId: id,
-        errors: errors,
-        modificationType: 'ADD',
-      })
-    );
-  }
-
-  /**
-   * Removes the given errors to the resource with the given id.
-   * @param id
-   * @param errors
-   */
-  public removeResourceErrors(
-    id: ResourceIdentifier,
-    errors: Array<ResourceError>
-  ) {
-    this.store.dispatch(
-      new ModifyStoreResourceErrorsAction({
-        resourceId: id,
-        errors: errors,
-        modificationType: 'REMOVE',
-      })
-    );
-  }
-
-  /**
-   * Sets the given errors to the resource with the given id.
-   * @param id
-   * @param errors
-   */
-  public setResourceErrors(
-    id: ResourceIdentifier,
-    errors: Array<ResourceError>
-  ) {
-    this.store.dispatch(
-      new ModifyStoreResourceErrorsAction({
-        resourceId: id,
-        errors: errors,
-        modificationType: 'SET',
-      })
-    );
-  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,19 @@ import {
   ErrorModificationType,
 } from './interfaces';
 
+
+export function setIn(state: any, path:string, value: any){
+  let currentValue = _.get(state, path);
+  if(value === currentValue){
+    return state;
+  }
+  return _.setWith(_.clone(state), path, value, (nsValue: any, key: string, nsObject: any) => {
+    const newObject = _.clone(nsObject);
+    newObject[key] = nsValue;
+    return newObject;
+  });
+}
+
 export const denormaliseObject = (
   resource: Resource,
   storeData: NgrxJsonApiStoreData,
@@ -682,9 +695,11 @@ export const updateQueryResults = (
       loading: false,
     };
 
-    let newState: NgrxJsonApiStoreQueries = { ...storeQueries };
-    newState[queryId] = <StoreQuery>newQueryStore;
-    return newState;
+    if(!_.isEqual(newQueryStore, storeQuery)){
+      let newState: NgrxJsonApiStoreQueries = { ...storeQueries };
+      newState[queryId] = <StoreQuery>newQueryStore;
+      return newState;
+    }
   }
   return storeQueries;
 };


### PR DESCRIPTION
introduced new concept of zones to isolate multiple instances of ngrx-json-api:

- actions carry zoneId
- NgrxJsonApiService.getZone(...) allows access to zone-specific actions.
- NgrxJsonApiService continues to provide access to default zone.
- top-level layout in store changed with {zones:{default:{...}} data structure. Mostly hidden from consumers by providing updated selector functions.
- selector service deprecated in favor of pure functions. No need for a service.
- NGRX_JSON_API_DEFAULT_ZONE constant introduced.
- initialNgrxJsonApiZone constant introduced for empty zone.