### PR TITLE
Accept page-based params (page[number] and page[size])

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -134,8 +134,7 @@ export class NgrxJsonApi {
     let fieldsParams = '';
     let offsetParams = '';
     let limitParams = '';
-    let pageNumberParams = '';
-    let pageSizeParams = '';
+    let pageParams = '';
 
     if (typeof query === undefined) {
       return Observable.throw('Query not found');
@@ -160,11 +159,12 @@ export class NgrxJsonApi {
       if (_.hasIn(query.params, 'offset')) {
         offsetParams = 'page[offset]=' + query.params.offset;
       }
-      if (_.hasIn(query.params, 'pageNumber')) {
-        pageNumberParams = 'page[number]=' + query.params.pageNumber;
-      }
-      if (_.hasIn(query.params, 'pageSize')) {
-        pageSizeParams = 'page[size]=' + query.params.pageSize;
+      if (_.hasIn(query.params, 'page')) {
+        pageParams = _.keys(query.params.page)
+          .map(key => {
+            return `page[${key}]=${query.params.page[key]}`;
+          })
+          .join('&');
       }
     }
     queryParams = _generateQueryParams(
@@ -174,8 +174,7 @@ export class NgrxJsonApi {
       fieldsParams,
       offsetParams,
       limitParams,
-      pageNumberParams,
-      pageSizeParams
+      pageParams
     );
 
     let requestOptions = {

--- a/src/api.ts
+++ b/src/api.ts
@@ -134,6 +134,8 @@ export class NgrxJsonApi {
     let fieldsParams = '';
     let offsetParams = '';
     let limitParams = '';
+    let pageNumberParams = '';
+    let pageSizeParams = '';
 
     if (typeof query === undefined) {
       return Observable.throw('Query not found');
@@ -158,6 +160,12 @@ export class NgrxJsonApi {
       if (_.hasIn(query.params, 'offset')) {
         offsetParams = 'page[offset]=' + query.params.offset;
       }
+      if (_.hasIn(query.params, 'pageNumber')) {
+        pageNumberParams = 'page[number]=' + query.params.pageNumber;
+      }
+      if (_.hasIn(query.params, 'pageSize')) {
+        pageSizeParams = 'page[size]=' + query.params.pageSize;
+      }
     }
     queryParams = _generateQueryParams(
       includedParam,
@@ -165,7 +173,9 @@ export class NgrxJsonApi {
       sortingParams,
       fieldsParams,
       offsetParams,
-      limitParams
+      limitParams,
+      pageNumberParams,
+      pageSizeParams
     );
 
     let requestOptions = {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -149,6 +149,8 @@ export interface QueryParams {
   fields?: Array<string>;
   offset?: number;
   limit?: number;
+  pageNumber?: number;
+  pageSize?: number;
 }
 
 export interface Resource extends ResourceIdentifier {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -149,8 +149,7 @@ export interface QueryParams {
   fields?: Array<string>;
   offset?: number;
   limit?: number;
-  pageNumber?: number;
-  pageSize?: number;
+  page?: { [key: string]: string };
 }
 
 export interface Resource extends ResourceIdentifier {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -149,7 +149,15 @@ export interface QueryParams {
   fields?: Array<string>;
   offset?: number;
   limit?: number;
-  page?: { [key: string]: string };
+  page?: QueryPageParams;
+}
+
+export interface QueryPageParams {
+  [id: string]: string | number;
+  offset?: number;
+  limit?: number;
+  number?: number;
+  size?: number;
 }
 
 export interface Resource extends ResourceIdentifier {


### PR DESCRIPTION
It is not defined the value of key of page in jsonapi.
http://jsonapi.org/format/#fetching-pagination

In our project, we are using `number` and `size` instead of `offset` and `limit`  as parmeters of pagination, so I'm stuck. Could you please help me?