### PR TITLE
Use boolean type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -230,7 +230,7 @@ export interface OneQueryResult extends QueryResult {
 
 export interface StoreQuery {
   query: Query;
-  loading: Boolean;
+  loading: boolean;
   resultIds?: Array<ResourceIdentifier>;
   meta?: any;
   links?: any;


### PR DESCRIPTION
To avoid the error below on assigning `loading`.

```
error TS2322: Type 'Boolean' is not assignable to type 'boolean'.
  'boolean' is a primitive, but 'Boolean' is a wrapper object. Prefer using 'boolean' when possible.
```