### PR TITLE
jaSelectStoreResources pipe

### DIFF
--- a/spec/pipes.spec.ts
+++ b/spec/pipes.spec.ts
@@ -5,6 +5,7 @@ import {
   DenormaliseStoreResourcePipe,
   GetDenormalisedValuePipe,
   SelectStoreResourcePipe,
+  SelectStoreResourcesPipe,
 } from '../src/pipes';
 
 import { denormaliseStoreResource } from '../src/utils';
@@ -21,6 +22,7 @@ describe('Pipes', () => {
         DenormaliseStoreResourcePipe,
         GetDenormalisedValuePipe,
         SelectStoreResourcePipe,
+        SelectStoreResourcesPipe,
       ],
     });
   });
@@ -69,6 +71,22 @@ describe('Pipes', () => {
         pipe = p;
       })
     );
+  });
+
+  describe('SelectStoreResourcesPipe', () => {
+    beforeEach(
+      inject([SelectStoreResourcesPipe], p => {
+        pipe = p;
+      })
+    );
+
+    it('should return Observable of StoreResource', () => {
+      const ids = [{id: '2', type: 'Article'}, {id: '1', type: 'Article'}]
+      pipe.transform(ids).subscribe(it => {
+        expect(_.get(it[0], 'attributes.title')).toBe('Article 2');
+        expect(_.get(it[1], 'attributes.title')).toBe('Article 1');
+      });
+    });
   });
 
   describe('DenormaliseStoreResourcePipe', () => {

--- a/spec/selectors.spec.ts
+++ b/spec/selectors.spec.ts
@@ -10,6 +10,7 @@ import {
   selectOneQueryResult,
   selectStoreQuery,
   selectStoreResource,
+  selectStoreResources,
   selectStoreResourcesOfType,
 } from '../src/selectors';
 import { NgrxJsonApiZone } from '../src/interfaces';
@@ -205,6 +206,39 @@ describe('NgrxJsonApiSelectors', () => {
             .subscribe(d => (res = d));
           tick();
           expect(res).not.toBeDefined();
+        })
+      );
+    });
+
+    describe('selectStoreResources', () => {
+      it(
+        'should get resources given types and ids',
+        fakeAsync(() => {
+          let res;
+          let sub = store
+            .let(selectStoreResources([{ type: 'Article', id: '1' }, { type: 'Article', id: '2'}]))
+            .subscribe(d => (res = d));
+          tick();
+          expect(res[0].attributes.title).toEqual('Article 1');
+          expect(res[0].type).toEqual('Article');
+          expect(res[0].id).toEqual('1');
+          expect(res[1].attributes.title).toEqual('Article 2');
+          expect(res[1].type).toEqual('Article');
+          expect(res[1].id).toEqual('2');
+        })
+      );
+
+      it(
+        'should return undefined if the resources are not found',
+        fakeAsync(() => {
+          let res;
+          let sub = store
+            .let(selectStoreResources([{ type: 'Article', id: '100' }, { type: 'Article', id: '1'}, {type: 'Unknown', id: '1'}]))
+            .subscribe(d => (res = d));
+          tick();
+          expect(res[0]).not.toBeDefined();
+          expect(res[1]).toBeDefined();
+          expect(res[2]).not.toBeDefined();
         })
       );
     });

--- a/spec/services.spec.ts
+++ b/spec/services.spec.ts
@@ -95,6 +95,27 @@ describe('NgrxJsonApiService', () => {
     });
   });
 
+  describe('selectStoreResources', () => {
+    it('should return resources', () => {
+      let storeResources = service.selectStoreResources([
+        {
+          type: 'Article',
+          id: '1',
+        },
+        {
+          type: 'Article',
+          id: '2',
+        }
+      ]);
+      storeResources.subscribe(it => {
+        expect(it[0].type).toEqual('Article');
+        expect(it[0].id).toEqual('1');
+        expect(it[1].type).toEqual('Article');
+        expect(it[1].id).toEqual('2');
+      });
+    });
+  });
+
   describe('findMany', () => {
     it('find multiple StoreResources from the state', () => {
       let query = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './interfaces';
 export {
   SelectStoreResourcePipe,
+  SelectStoreResourcesPipe,
   DenormaliseStoreResourcePipe,
   GetDenormalisedValuePipe,
 } from './pipes';

--- a/src/pipes.ts
+++ b/src/pipes.ts
@@ -15,6 +15,15 @@ export class SelectStoreResourcePipe implements PipeTransform {
   }
 }
 
+@Pipe({ name: 'jaSelectStoreResources' })
+export class SelectStoreResourcesPipe implements PipeTransform {
+  constructor(private service: NgrxJsonApiService) {}
+
+  transform(ids: ResourceIdentifier[]): Observable<StoreResource[]> {
+    return this.service.selectStoreResources(ids);
+  }
+}
+
 @Pipe({ name: 'denormaliseStoreResource' })
 export class DenormaliseStoreResourcePipe implements PipeTransform {
   constructor(private service: NgrxJsonApiService) {}

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -90,6 +90,21 @@ export function selectStoreResource(identifier: ResourceIdentifier) {
   };
 }
 
+export function selectStoreResources(identifiers: ResourceIdentifier[]) {
+  return (state$: Observable<NgrxJsonApiStore>) => {
+    return state$.pipe(
+      map(state => state.data),
+      map(data => {
+        return identifiers.map(identifier => {
+          if (!data || !data[identifier.type]) {
+            return undefined;
+          }
+          return data[identifier.type][identifier.id] as StoreResource;
+        });
+      }));
+  };
+}
+
 export function selectManyQueryResult(
   queryId: string,
   denormalize?: boolean

--- a/src/services.ts
+++ b/src/services.ts
@@ -11,6 +11,7 @@ import {
   selectNgrxJsonApiZone,
   selectOneQueryResult,
   selectStoreResource,
+  selectStoreResources,
 } from './selectors';
 import {
   ApiApplyInitAction,
@@ -172,6 +173,18 @@ export class NgrxJsonApiZoneService {
     return this.store
       .let(selectNgrxJsonApiZone(this.zoneId))
       .let(selectStoreResource(identifier));
+  }
+
+  /**
+   * @param identifiers of the resources
+   * @returns observable of the resources
+   */
+  public selectStoreResources(
+    identifiers: ResourceIdentifier[]
+  ): Observable<StoreResource[]> {
+    return this.store
+      .let(selectNgrxJsonApiZone(this.zoneId))
+      .let(selectStoreResources(identifiers));
   }
 
   /**


### PR DESCRIPTION
plural version of `jaSelectStoreResource`

it can be used as `{{person.relationships.blogs.data | jaSelectStoreResources as blogs}}` instead of using `*ngFor` and `jaSelectStoreResource` inside of it.
