### PR TITLE
add requestWithCredentials option to NgrxJsonApiConfig

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -239,6 +239,7 @@ export class NgrxJsonApi {
       ...requestOptions,
       headers: this.headers,
       observe: 'response',
+      withCredentials: this.config.requestWithCredentials,
     };
 
     if (requestOptions.method === 'GET') {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,6 +65,13 @@ export interface NgrxJsonApiConfig {
    * have a look at www.crnk.io that makes use of JSON PATCH to perform bulk updates.
    */
   applyEnabled?: boolean;
+  /**
+   * Allows to send/receive cookies, authorization headers with cross-site request.
+   * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials
+   *
+   * default is false
+   */
+  requestWithCredentials?: boolean;
 }
 
 export interface NgrxJsonApiState {


### PR DESCRIPTION
Allows to send/receive cookies, authorization headers with cross-site request.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials