### PR TITLE
fix: NgrxJsonApiZoneService applies pending changes in reverse order

### DIFF
--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -805,12 +805,12 @@ describe('sortPendingChanges', () => {
     };
 
     let order = sortPendingChanges([resource1, resource2]);
-    expect(order[0].id).toEqual('1');
-    expect(order[1].id).toEqual('2');
+    expect(order[0].id).toEqual('2');
+    expect(order[1].id).toEqual('1');
 
     order = sortPendingChanges([resource2, resource1]);
-    expect(order[0].id).toEqual('1');
-    expect(order[1].id).toEqual('2');
+    expect(order[0].id).toEqual('2');
+    expect(order[1].id).toEqual('1');
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1282,7 +1282,7 @@ export const sortPendingChanges = (
     }
   }
 
-  return context.sorted;
+  return context.sorted.reverse();
 };
 
 const visitPending = (


### PR DESCRIPTION
This provide a fix for #280.