### PR TITLE
Send `meta` when creating/updating a resource

### DIFF
--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1776,6 +1776,19 @@ describe('generatePayload', () => {
     expect(payload.query.type).toEqual('Article');
     expect(payload.jsonApiData.data.id).toEqual('10');
     expect(payload.jsonApiData.data.type).toEqual('Article');
+    expect(payload.jsonApiData.meta).toBeUndefined();
+    let resourceWithMeta = {
+      ...resource,
+      meta: {
+        testMetaData: 'test',
+      },
+    };
+    let payloadWithMeta = generatePayload(resourceWithMeta, 'POST');
+    expect(payloadWithMeta.query.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.data.id).toEqual('10');
+    expect(payloadWithMeta.jsonApiData.data.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.meta).toBeDefined();
+    expect(payloadWithMeta.jsonApiData.meta.testMetaData).toEqual('test');
   });
 
   it('should generate a payload for a "update" request given a resource', () => {
@@ -1788,6 +1801,20 @@ describe('generatePayload', () => {
     expect(payload.query.type).toEqual('Article');
     expect(payload.jsonApiData.data.id).toEqual('10');
     expect(payload.jsonApiData.data.type).toEqual('Article');
+    expect(payload.jsonApiData.meta).toBeUndefined();
+    let resourceWithMeta = {
+      ...resource,
+      meta: {
+        testMetaData: 'test',
+      },
+    };
+    let payloadWithMeta = generatePayload(resourceWithMeta, 'PATCH');
+    expect(payloadWithMeta.query.id).toEqual('10');
+    expect(payloadWithMeta.query.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.data.id).toEqual('10');
+    expect(payloadWithMeta.jsonApiData.data.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.meta).toBeDefined();
+    expect(payloadWithMeta.jsonApiData.meta.testMetaData).toEqual('test');
   });
 
   it('should generate a payload for a "delete" request given a resource', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1043,6 +1043,11 @@ export const generatePayload = (
         attributes: resource.attributes,
         relationships: resource.relationships,
       },
+      ...(resource.meta
+        ? {
+            meta: resource.meta,
+          }
+        : null),
     };
   }
 


### PR DESCRIPTION
This resolves #298.