### PR TITLE
Support "meta" property in diff mode

### DIFF
--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1776,6 +1776,19 @@ describe('generatePayload', () => {
     expect(payload.query.type).toEqual('Article');
     expect(payload.jsonApiData.data.id).toEqual('10');
     expect(payload.jsonApiData.data.type).toEqual('Article');
+    expect(payload.jsonApiData.meta).toBeUndefined();
+    let resourceWithMeta = {
+      ...resource,
+      meta: {
+        testMetaData: 'test',
+      },
+    };
+    let payloadWithMeta = generatePayload(resourceWithMeta, 'POST');
+    expect(payloadWithMeta.query.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.data.id).toEqual('10');
+    expect(payloadWithMeta.jsonApiData.data.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.meta).toBeDefined();
+    expect(payloadWithMeta.jsonApiData.meta.testMetaData).toEqual('test');
   });
 
   it('should generate a payload for a "update" request given a resource', () => {
@@ -1788,6 +1801,20 @@ describe('generatePayload', () => {
     expect(payload.query.type).toEqual('Article');
     expect(payload.jsonApiData.data.id).toEqual('10');
     expect(payload.jsonApiData.data.type).toEqual('Article');
+    expect(payload.jsonApiData.meta).toBeUndefined();
+    let resourceWithMeta = {
+      ...resource,
+      meta: {
+        testMetaData: 'test',
+      },
+    };
+    let payloadWithMeta = generatePayload(resourceWithMeta, 'PATCH');
+    expect(payloadWithMeta.query.id).toEqual('10');
+    expect(payloadWithMeta.query.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.data.id).toEqual('10');
+    expect(payloadWithMeta.jsonApiData.data.type).toEqual('Article');
+    expect(payloadWithMeta.jsonApiData.meta).toBeDefined();
+    expect(payloadWithMeta.jsonApiData.meta.testMetaData).toEqual('test');
   });
 
   it('should generate a payload for a "delete" request given a resource', () => {

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -1856,6 +1856,10 @@ describe('generatePayload', () => {
           ],
         },
       },
+      meta: {
+        updatedMeta: 'data',
+        keptMeta: 'same',
+      },
       persistedResource: {
         id: '10',
         type: 'Article',
@@ -1872,6 +1876,10 @@ describe('generatePayload', () => {
           existingEmptyToBeFilled: {
             data: [],
           },
+        },
+        meta: {
+          existingMeta: 'test',
+          keptMeta: 'same',
         },
       },
     };
@@ -1900,5 +1908,9 @@ describe('generatePayload', () => {
       payload.jsonApiData.data.relationships.existingEmptyToBeFilled.data[0]
         .type
     ).toEqual('foo-type');
+    expect(payload.jsonApiData.meta).toBeDefined();
+    expect(payload.jsonApiData.meta.existingMeta).toBeUndefined();
+    expect(payload.jsonApiData.meta.updatedMeta).toBeDefined();
+    expect(payload.jsonApiData.meta.keptMeta).toBeDefined();
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1069,7 +1069,10 @@ export const generatePayload = (
               )
             : resource.relationships,
       },
-      ...(resource.meta
+      ...(resource.meta &&
+      (operation !== 'PATCH' ||
+        !diffUpdate ||
+        updatedData(resource.persistedResource.meta, resource.meta))
         ? {
             meta: resource.meta,
           }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1043,6 +1043,11 @@ export const generatePayload = (
         attributes: resource.attributes,
         relationships: resource.relationships,
       },
+      ...(resource.meta
+        ? {
+            meta: resource.meta,
+          }
+        : null),
     };
   }
 


### PR DESCRIPTION
Following #287 & #299, there's a need for explicit support of the "meta" property when submitting only updated data instead of the whole resource. 